### PR TITLE
fix: 修复识别异常并恢复 MaaFramework schema 同步

### DIFF
--- a/.github/workflows/sync_schema_files.yml
+++ b/.github/workflows/sync_schema_files.yml
@@ -10,24 +10,8 @@ permissions:
   contents: read
 
 jobs:
-  check-repository:
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-    steps:
-      - id: check
-        run: |
-          if [[ "${{ github.repository }}" == "MaaXYZ/MaaPracticeBoilerplate" ]]; then
-            echo "Repository is MaaXYZ/MaaPracticeBoilerplate, proceeding with sync"
-            echo "should_run=true" >> $GITHUB_OUTPUT
-          else
-            echo "Repository is not MaaXYZ/MaaPracticeBoilerplate, skipping sync"
-            echo "should_run=false" >> $GITHUB_OUTPUT
-          fi
-
   sync-schema-files:
-    needs: check-repository
-    if: needs.check-repository.outputs.should_run == 'true'
+    if: github.repository == 'MaaStellaSora/MaaStellaSora'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -40,52 +24,40 @@ jobs:
         run: |
           echo "Current Date and Time (UTC): $(date -u '+%Y-%m-%d %H:%M:%S')"
 
-          # 确保目标目录存在
           mkdir -p deps/tools
+          schemas=(
+            custom.action.schema.json
+            custom.recognition.schema.json
+            interface.schema.json
+            interface_config.schema.json
+            interface_import.schema.json
+            pipeline.schema.json
+          )
 
-          # 下载四个JSON schema文件
-          curl -s -o deps/tools/interface.schema.json https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/interface.schema.json || echo "Failed to download interface.schema.json"
-          curl -s -o deps/tools/interface_config.schema.json https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/interface_config.schema.json || echo "Failed to download interface_config.schema.json"
-          curl -s -o deps/tools/pipeline.schema.json https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/pipeline.schema.json || echo "Failed to download pipeline.schema.json"
+          for schema in "${schemas[@]}"; do
+            temporary="deps/tools/${schema}.tmp"
+            curl --fail --location --show-error --silent --retry 3 \
+              --output "$temporary" \
+              "https://raw.githubusercontent.com/MaaXYZ/MaaFramework/main/tools/${schema}"
+            python -m json.tool "$temporary" >/dev/null
+            mv "$temporary" "deps/tools/${schema}"
+          done
 
-          # 检查文件是否成功下载
           echo "Checking downloaded files:"
           ls -la deps/tools/*.schema.json
 
       - name: Check for changes with git status
         id: check_status
         run: |
-          # 确保git能看到未跟踪的文件
           git add -N deps/tools/
 
-          # 检查是否有任何更改（修改、新增、删除）
           if [[ -n "$(git status --porcelain deps/tools/*.schema.json)" ]]; then
             echo "Changes detected in JSON schema files"
             git status --porcelain deps/tools/*.schema.json
             echo "changes_detected=true" >> $GITHUB_OUTPUT
-            
-            # 检查哪些文件发生了变化
-            if [[ -n "$(git status --porcelain deps/tools/interface.schema.json)" ]]; then
-              echo "interface_changed=true" >> $GITHUB_OUTPUT
-            else
-              echo "interface_changed=false" >> $GITHUB_OUTPUT
-            fi
-            if [[ -n "$(git status --porcelain deps/tools/interface_config.schema.json)" ]]; then
-              echo "interface_config_changed=true" >> $GITHUB_OUTPUT
-            else
-              echo "interface_config_changed=false" >> $GITHUB_OUTPUT
-            fi
-            if [[ -n "$(git status --porcelain deps/tools/pipeline.schema.json)" ]]; then
-              echo "pipeline_changed=true" >> $GITHUB_OUTPUT
-            else
-              echo "pipeline_changed=false" >> $GITHUB_OUTPUT
-            fi
           else
             echo "No changes detected in JSON schema files"
             echo "changes_detected=false" >> $GITHUB_OUTPUT
-            echo "interface_changed=false" >> $GITHUB_OUTPUT
-            echo "interface_config_changed=false" >> $GITHUB_OUTPUT
-            echo "pipeline_changed=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Commit and Push Changes
@@ -95,24 +67,7 @@ jobs:
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git add deps/tools/*.schema.json
-          timestamp=$(date -u "+%Y-%m-%d %H:%M:%S")
-
-          # 创建定制的提交消息
-          changed_files=""
-          if [[ "${{ steps.check_status.outputs.interface_changed }}" == "true" ]]; then
-            changed_files+="interface "
-          fi
-          if [[ "${{ steps.check_status.outputs.interface_config_changed }}" == "true" ]]; then
-            changed_files+="interface_config "
-          fi
-          if [[ "${{ steps.check_status.outputs.pipeline_changed }}" == "true" ]]; then
-            changed_files+="pipeline "
-          fi
-
-          # 去除末尾空格
-          changed_files=$(echo "$changed_files" | xargs)
-
-          git commit -m "chore: update $changed_files schema files from MaaFramework - $timestamp UTC"
+          git commit -m "chore(deps): sync MaaFramework schemas"
           git push
 
           echo "JSON schema files successfully synchronized"

--- a/agent/custom/action/climb_tower_potential.py
+++ b/agent/custom/action/climb_tower_potential.py
@@ -640,7 +640,10 @@ class ScreenDataProcessor:
         )
 
         hit_x = result_boxes[0][0] if result_boxes else -1
-        matched = next(i for i, (low, high) in enumerate(borders) if low <= hit_x <= high)
+        matched = next(
+            (i for i, (low, high) in enumerate(borders) if low <= hit_x <= high),
+            None,
+        )
 
         if matched is None:
             logger.error("拿走按钮识别失败，潜能选择可能会出现问题")

--- a/agent/custom/reco/operation.py
+++ b/agent/custom/reco/operation.py
@@ -52,8 +52,12 @@ class EnoughTrackingPermitRecognition(CustomRecognition):
 
         keep_count = _get_tracking_permit_keep_count(context)
         count = _get_resource_count(context, argv.image)
+        if count is None:
+            logger.debug("未识别到追踪委托书数量")
+            return CustomRecognition.AnalyzeResult(box=None, detail={})
+
         usable = count - keep_count
-        if not count or usable <= 0:
+        if count <= 0 or usable <= 0:
             logger.debug(f"追踪委托书数量{count}小于等于保留数量{keep_count}或数量为0")
             return CustomRecognition.AnalyzeResult(box=None, detail={})
         

--- a/deps/tools/interface.schema.json
+++ b/deps/tools/interface.schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MaaFramework Project Interface V2",
-    "description": "MaaFramework 项目接口配置文件 V2 版本的 JSON Schema",
+    "description": "MaaFramework 项目接口配置文件 V2 版本的 JSON Schema。",
     "type": "object",
     "definitions": {
         "i18nString": {
@@ -12,16 +12,16 @@
             "type": "object",
             "title": "Pipeline 覆盖配置",
             "description": "用于覆盖已加载资源中的 pipeline 配置",
-            "$ref": "./pipeline.schema.json"
+            "additionalProperties": true
         },
         "caseItem": {
             "type": "object",
-            "title": "选项项",
+            "title": "选项",
             "properties": {
                 "name": {
                     "type": "string",
                     "title": "选项唯一标识符",
-                    "description": "用作选项ID"
+                    "description": "用作选项 ID"
                 },
                 "label": {
                     "$ref": "#/definitions/i18nString",
@@ -31,7 +31,7 @@
                 "description": {
                     "$ref": "#/definitions/i18nString",
                     "title": "详细描述",
-                    "description": "支持文件路径、URL或直接文本，内容支持Markdown格式"
+                    "description": "支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                 },
                 "icon": {
                     "$ref": "#/definitions/i18nString",
@@ -64,7 +64,7 @@
                 "name": {
                     "type": "string",
                     "title": "输入字段唯一标识符",
-                    "description": "用作输入字段ID"
+                    "description": "用作输入字段 ID"
                 },
                 "label": {
                     "$ref": "#/definitions/i18nString",
@@ -74,7 +74,7 @@
                 "description": {
                     "$ref": "#/definitions/i18nString",
                     "title": "详细描述",
-                    "description": "帮助用户理解输入要求。支持文件路径、URL或直接文本，内容支持Markdown格式"
+                    "description": "帮助用户理解输入要求。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                 },
                 "default": {
                     "type": "string",
@@ -107,89 +107,112 @@
             ],
             "additionalProperties": false
         },
-        "optionDefinition": {
+        "hotkeyItem": {
             "type": "object",
-            "title": "配置项定义",
+            "title": "快捷键字段",
             "properties": {
-                "type": {
+                "name": {
                     "type": "string",
-                    "title": "配置项类型",
-                    "description": "select: 下拉选项框; input: 用户输入框; switch: 选择框(Yes or No)",
-                    "enum": [
-                        "select",
-                        "input",
-                        "switch"
-                    ],
-                    "default": "select"
+                    "title": "快捷键字段唯一标识符",
+                    "description": "用作快捷键字段 ID"
                 },
                 "label": {
                     "$ref": "#/definitions/i18nString",
-                    "title": "显示标签",
-                    "description": "用于在用户界面中展示，支持国际化"
+                    "title": "显示名称",
+                    "description": "用于在用户界面中展示，支持国际化。如果未设置，则显示 name 字段的值"
                 },
                 "description": {
                     "$ref": "#/definitions/i18nString",
                     "title": "详细描述",
-                    "description": "帮助用户理解配置项的作用。支持文件路径、URL或直接文本，内容支持Markdown格式"
+                    "description": "帮助用户理解该快捷键的用途。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                 },
-                "icon": {
-                    "$ref": "#/definitions/i18nString",
-                    "title": "图标路径",
-                    "description": "配置项图标文件路径，相对于项目根目录"
-                },
-                "cases": {
-                    "type": "array",
-                    "title": "可选项列表",
-                    "description": "在 type 为 select/switch 时使用",
-                    "items": {
-                        "$ref": "#/definitions/caseItem"
-                    }
-                },
-                "inputs": {
-                    "type": "array",
-                    "title": "输入配置",
-                    "description": "在 type 为 input 时使用，定义用户可输入的字段",
-                    "items": {
-                        "$ref": "#/definitions/inputItem"
-                    }
-                },
-                "pipeline_override": {
-                    "$ref": "#/definitions/pipelineOverride",
-                    "title": "Pipeline 覆盖模板",
-                    "description": "当配置项为 input 类型时使用，支持使用 {名称} 格式引用输入字段的值"
-                },
-                "default_case": {
+                "default": {
                     "type": "string",
-                    "title": "默认选项",
-                    "description": "默认选项名称，仅在 type 为 select 时使用"
+                    "title": "默认值",
+                    "description": "💡 v2.8.0 人类可读的快捷键字符串，如 \"E\"、\"1\"、\"ALT+A\"，无需填写虚拟按键码"
                 }
             },
-            "additionalProperties": false,
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false
+        },
+        "optionControllerResource": {
+            "type": "object",
+            "properties": {
+                "controller": {
+                    "type": "array",
+                    "title": "适用的控制器",
+                    "description": "💡 v2.3.0 可选。指定该配置项适用的控制器类型列表。数组元素应与 controller 配置中的 name 字段对应。若不指定，则表示该配置项在所有控制器类型中都可用",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "resource": {
+                    "type": "array",
+                    "title": "适用的资源包",
+                    "description": "💡 v2.3.0 可选。指定该配置项适用的资源包列表。数组元素应与 resource 配置中的 name 字段对应。若不指定，则表示该配置项在所有资源包中都可用",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "optionDefinition": {
+            "type": "object",
+            "title": "配置项定义",
             "oneOf": [
                 {
                     "title": "inputOption",
                     "type": "object",
                     "properties": {
                         "type": {
-                            "const": "input"
+                            "const": "input",
+                            "description": "用户输入框，允许用户手动输入内容"
                         },
                         "label": {
-                            "$ref": "#/definitions/i18nString"
+                            "$ref": "#/definitions/i18nString",
+                            "title": "显示标签",
+                            "description": "用于在用户界面中展示，支持国际化"
                         },
                         "description": {
-                            "$ref": "#/definitions/i18nString"
+                            "$ref": "#/definitions/i18nString",
+                            "title": "详细描述",
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                         },
                         "icon": {
-                            "$ref": "#/definitions/i18nString"
+                            "$ref": "#/definitions/i18nString",
+                            "title": "图标路径",
+                            "description": "配置项图标文件路径，相对于项目根目录"
+                        },
+                        "controller": {
+                            "type": "array",
+                            "title": "适用的控制器",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的控制器类型列表",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "resource": {
+                            "type": "array",
+                            "title": "适用的资源包",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的资源包列表",
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "inputs": {
                             "type": "array",
+                            "title": "输入配置",
+                            "description": "定义用户可输入的字段",
                             "items": {
                                 "$ref": "#/definitions/inputItem"
                             }
                         },
                         "pipeline_override": {
-                            "$ref": "#/definitions/pipelineOverride"
+                            "$ref": "#/definitions/pipelineOverride",
+                            "title": "Pipeline 覆盖模板",
+                            "description": "支持使用「名称」格式引用输入字段的值"
                         }
                     },
                     "required": [
@@ -199,29 +222,177 @@
                     "additionalProperties": false
                 },
                 {
+                    "title": "hotkeyOption",
+                    "type": "object",
+                    "description": "💡 v2.8.0 快捷键捕获框，允许用户通过按键捕获快捷键",
+                    "properties": {
+                        "type": {
+                            "const": "hotkey",
+                            "description": "💡 v2.8.0 快捷键捕获框，允许用户通过按键捕获快捷键"
+                        },
+                        "label": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "显示标签",
+                            "description": "用于在用户界面中展示，支持国际化"
+                        },
+                        "description": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "详细描述",
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                        },
+                        "icon": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "图标路径",
+                            "description": "配置项图标文件路径，相对于项目根目录"
+                        },
+                        "controller": {
+                            "type": "array",
+                            "title": "适用的控制器",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的控制器类型列表",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "resource": {
+                            "type": "array",
+                            "title": "适用的资源包",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的资源包列表",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "hotkeys": {
+                            "type": "array",
+                            "title": "快捷键配置",
+                            "description": "定义用户可捕获的快捷键字段；持久化值为人类可读字符串，pipeline_override 替换时映射为虚拟按键码整数",
+                            "items": {
+                                "$ref": "#/definitions/hotkeyItem"
+                            }
+                        },
+                        "pipeline_override": {
+                            "$ref": "#/definitions/pipelineOverride",
+                            "title": "Pipeline 覆盖模板",
+                            "description": "支持使用 {名称}、{名称}.primary、{名称}.modifier1 等占位符引用快捷键字段，替换结果为整数（虚拟按键码）"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "hotkeys"
+                    ],
+                    "additionalProperties": false
+                },
+                {
                     "title": "selectOption",
                     "type": "object",
                     "properties": {
                         "type": {
-                            "const": "select"
+                            "const": "select",
+                            "description": "下拉选项框，用户从预定义的选项中选择一个"
                         },
                         "label": {
-                            "$ref": "#/definitions/i18nString"
+                            "$ref": "#/definitions/i18nString",
+                            "title": "显示标签",
+                            "description": "用于在用户界面中展示，支持国际化"
                         },
                         "description": {
-                            "$ref": "#/definitions/i18nString"
+                            "$ref": "#/definitions/i18nString",
+                            "title": "详细描述",
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                         },
                         "icon": {
-                            "$ref": "#/definitions/i18nString"
+                            "$ref": "#/definitions/i18nString",
+                            "title": "图标路径",
+                            "description": "配置项图标文件路径，相对于项目根目录"
+                        },
+                        "controller": {
+                            "type": "array",
+                            "title": "适用的控制器",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的控制器类型列表",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "resource": {
+                            "type": "array",
+                            "title": "适用的资源包",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的资源包列表",
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "cases": {
                             "type": "array",
+                            "title": "可选项列表",
                             "items": {
                                 "$ref": "#/definitions/caseItem"
                             }
                         },
                         "default_case": {
-                            "type": "string"
+                            "type": "string",
+                            "title": "默认选项",
+                            "description": "默认选项名称"
+                        }
+                    },
+                    "required": [
+                        "cases"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "title": "checkboxOption",
+                    "type": "object",
+                    "description": "💡 v2.3.0 多选框，用户从预定义的选项中选择多个",
+                    "properties": {
+                        "type": {
+                            "const": "checkbox",
+                            "description": "💡 v2.3.0 多选框，用户从预定义的选项中选择多个"
+                        },
+                        "label": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "显示标签",
+                            "description": "用于在用户界面中展示，支持国际化"
+                        },
+                        "description": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "详细描述",
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                        },
+                        "icon": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "图标路径",
+                            "description": "配置项图标文件路径，相对于项目根目录"
+                        },
+                        "controller": {
+                            "type": "array",
+                            "title": "适用的控制器",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的控制器类型列表",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "resource": {
+                            "type": "array",
+                            "title": "适用的资源包",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的资源包列表",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cases": {
+                            "type": "array",
+                            "title": "可选项列表",
+                            "description": "用户可同时选中多个 case，所有被选中的 case 的 pipeline_override 会按照 cases 数组中的定义顺序依次合并生效",
+                            "items": {
+                                "$ref": "#/definitions/caseItem"
+                            }
+                        },
+                        "default_case": {
+                            "type": "array",
+                            "title": "默认选中项",
+                            "description": "💡 v2.3.0 默认选中的选项名称数组，Client 使用该值作为多选框的初始选中值",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     },
                     "required": [
@@ -235,28 +406,57 @@
                     "type": "object",
                     "properties": {
                         "type": {
-                            "const": "switch"
+                            "const": "switch",
+                            "description": "选择框，Yes or No"
                         },
                         "label": {
-                            "$ref": "#/definitions/i18nString"
+                            "$ref": "#/definitions/i18nString",
+                            "title": "显示标签",
+                            "description": "用于在用户界面中展示，支持国际化"
                         },
                         "description": {
-                            "$ref": "#/definitions/i18nString"
+                            "$ref": "#/definitions/i18nString",
+                            "title": "详细描述",
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                         },
                         "icon": {
-                            "$ref": "#/definitions/i18nString"
+                            "$ref": "#/definitions/i18nString",
+                            "title": "图标路径",
+                            "description": "配置项图标文件路径，相对于项目根目录"
+                        },
+                        "controller": {
+                            "type": "array",
+                            "title": "适用的控制器",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的控制器类型列表",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "resource": {
+                            "type": "array",
+                            "title": "适用的资源包",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的资源包列表",
+                            "items": {
+                                "type": "string"
+                            }
                         },
                         "cases": {
                             "type": "array",
+                            "title": "可选项列表",
+                            "description": "仅支持两个 cases。case.name 应为 Yes/yes/Y/y 或 No/no/N/n 之一，建议使用 Yes 和 No",
                             "minItems": 2,
                             "maxItems": 2,
                             "items": {
                                 "$ref": "#/definitions/caseItem"
                             }
+                        },
+                        "default_case": {
+                            "type": "string",
+                            "title": "默认选项",
+                            "description": "默认选项名称，应为 Yes 或 No"
                         }
                     },
                     "required": [
-                        "type",
                         "cases"
                     ],
                     "additionalProperties": false
@@ -270,7 +470,7 @@
                 "name": {
                     "type": "string",
                     "title": "唯一名称标识符",
-                    "description": "用作控制器ID"
+                    "description": "用作控制器 ID"
                 },
                 "label": {
                     "$ref": "#/definitions/i18nString",
@@ -280,7 +480,7 @@
                 "description": {
                     "$ref": "#/definitions/i18nString",
                     "title": "详细描述",
-                    "description": "支持文件路径、URL或直接文本，内容支持Markdown格式"
+                    "description": "支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                 },
                 "icon": {
                     "$ref": "#/definitions/i18nString",
@@ -292,7 +492,11 @@
                     "title": "控制器类型",
                     "enum": [
                         "Adb",
-                        "Win32"
+                        "Win32",
+                        "MacOS",
+                        "PlayCover",
+                        "Gamepad",
+                        "Linux"
                     ]
                 },
                 "display_short_side": {
@@ -311,6 +515,34 @@
                     "title": "使用原始分辨率",
                     "description": "是否使用原始分辨率进行截图，不进行缩放。与缩放分辨率设置互斥",
                     "default": false
+                },
+                "permission_required": {
+                    "type": "boolean",
+                    "title": "需要管理员权限",
+                    "description": "该控制器是否需要以管理员权限运行（例如某些 Win32 输入方式需要更高权限）。不设置则默认为 false",
+                    "default": false
+                },
+                "attach_resource_path": {
+                    "type": "array",
+                    "title": "附加资源路径",
+                    "description": "可选。附加资源路径数组。将会在 resource.path 加载完成后，额外加载这些路径下的资源",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "option": {
+                    "type": "array",
+                    "title": "控制器级选项配置",
+                    "description": "💡 v2.3.0 可选。控制器级的选项配置，为一个字符串数组，数组元素应与外层 option 配置中的键名对应。该选项生成的参数会参与到所有使用该控制器的任务的 pipeline override 中",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "adb": {
+                    "type": "object",
+                    "title": "Adb 控制器配置",
+                    "description": "Adb 控制器的具体配置。V2 协议中 input/screencap 由 MaaFramework 自动检测，无需手动配置",
+                    "additionalProperties": true
                 },
                 "win32": {
                     "type": "object",
@@ -336,9 +568,12 @@
                                 "SendMessage",
                                 "PostMessage",
                                 "LegacyEvent",
-                                "PostThreadMessage",
                                 "SendMessageWithCursorPos",
-                                "PostMessageWithCursorPos"
+                                "PostMessageWithCursorPos",
+                                "SendMessageWithWindowPos",
+                                "PostMessageWithWindowPos",
+                                "Interception",
+                                "AnchoredTouch"
                             ]
                         },
                         "keyboard": {
@@ -350,9 +585,10 @@
                                 "SendMessage",
                                 "PostMessage",
                                 "LegacyEvent",
-                                "PostThreadMessage",
                                 "SendMessageWithCursorPos",
-                                "PostMessageWithCursorPos"
+                                "PostMessageWithCursorPos",
+                                "SendMessageWithWindowPos",
+                                "PostMessageWithWindowPos"
                             ]
                         },
                         "screencap": {
@@ -365,8 +601,141 @@
                                 "DXGI_DesktopDup",
                                 "DXGI_DesktopDup_Window",
                                 "PrintWindow",
+                                "ScreenDC",
+                                "Foreground",
+                                "Background"
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "macos": {
+                    "type": "object",
+                    "title": "MacOS 控制器配置",
+                    "description": "MacOS 控制器的具体配置",
+                    "properties": {
+                        "title_regex": {
+                            "type": "string",
+                            "title": "窗口标题正则",
+                            "description": "可选。MacOS 控制器搜索窗口标题使用的正则表达式"
+                        },
+                        "input": {
+                            "type": "string",
+                            "title": "输入控制方式",
+                            "description": "可选。MacOS 控制器的输入控制方式，不提供则使用默认",
+                            "enum": [
+                                "GlobalEvent",
+                                "PostToPid"
+                            ]
+                        },
+                        "screencap": {
+                            "type": "string",
+                            "title": "截图方式",
+                            "description": "可选。MacOS 控制器的截图方式，不提供则使用默认",
+                            "enum": [
+                                "ScreenCaptureKit"
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "playcover": {
+                    "type": "object",
+                    "title": "PlayCover 控制器配置",
+                    "description": "PlayCover 控制器的具体配置（仅 macOS）",
+                    "properties": {
+                        "uuid": {
+                            "type": "string",
+                            "title": "Bundle Identifier",
+                            "description": "可选。目标应用的 Bundle Identifier，不提供则使用默认 maa.playcover，仅作为控制器标识符，与被操控应用无关",
+                            "examples": [
+                                "com.hypergryph.arknights"
+                            ]
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "gamepad": {
+                    "type": "object",
+                    "title": "Gamepad 控制器配置",
+                    "description": "虚拟游戏手柄控制器的具体配置（仅 Windows）。需要安装 ViGEm Bus Driver",
+                    "properties": {
+                        "class_regex": {
+                            "type": "string",
+                            "title": "窗口类名正则",
+                            "description": "可选。搜索窗口类名使用的正则表达式，用于截图功能"
+                        },
+                        "window_regex": {
+                            "type": "string",
+                            "title": "窗口标题正则",
+                            "description": "可选。搜索窗口标题使用的正则表达式，用于截图功能"
+                        },
+                        "gamepad_type": {
+                            "type": "string",
+                            "title": "手柄类型",
+                            "description": "可选。虚拟手柄类型，不提供则默认使用 Xbox360",
+                            "enum": [
+                                "Xbox360",
+                                "DualShock4",
+                                "DS4"
+                            ],
+                            "default": "Xbox360"
+                        },
+                        "screencap": {
+                            "type": "string",
+                            "title": "截图方式",
+                            "description": "可选。截图方式，不提供则使用默认。仅当配置了窗口正则时有效",
+                            "enum": [
+                                "GDI",
+                                "FramePool",
+                                "DXGI_DesktopDup",
+                                "DXGI_DesktopDup_Window",
+                                "PrintWindow",
                                 "ScreenDC"
                             ]
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "linux": {
+                    "type": "object",
+                    "title": "Linux 控制器配置",
+                    "description": "Linux 控制器的具体配置",
+                    "properties": {
+                        "input": {
+                            "type": "string",
+                            "title": "输入控制方式",
+                            "description": "可选。Linux 控制器的输入控制方式，不提供则使用默认",
+                            "enum": [
+                                "Wlr",
+                                "UInput",
+                                "Libei"
+                            ]
+                        },
+                        "screencap": {
+                            "type": "string",
+                            "title": "截图方式",
+                            "description": "可选。Linux 控制器的截图方式，不提供则使用默认",
+                            "enum": [
+                                "Wlr",
+                                "PipeWire"
+                            ]
+                        },
+                        "pipewire_source": {
+                            "type": "string",
+                            "title": "PipeWire 截图来源",
+                            "description": "可选。PipeWire 截图的流来源。Gamescope 直接连接 gamescope 节点（node id 运行时发现）；Portal 走 xdg-desktop-portal ScreenCast。仅当 screencap 为 PipeWire 时有效",
+                            "enum": [
+                                "Gamescope",
+                                "Portal"
+                            ],
+                            "default": "Gamescope"
+                        },
+                        "use_win32_vk_code": {
+                            "type": "boolean",
+                            "title": "使用 Win32 VK 键码",
+                            "description": "可选。为 true 时按键被视为 Win32 Virtual-Key 码，内部转换为 Linux evdev 码；否则按原始 evdev 码处理。默认 false",
+                            "default": false
                         }
                     },
                     "additionalProperties": false
@@ -385,7 +754,7 @@
                 "name": {
                     "type": "string",
                     "title": "唯一名称标识符",
-                    "description": "用作资源包ID"
+                    "description": "用作资源包 ID"
                 },
                 "label": {
                     "$ref": "#/definitions/i18nString",
@@ -395,7 +764,7 @@
                 "description": {
                     "$ref": "#/definitions/i18nString",
                     "title": "详细描述",
-                    "description": "支持文件路径、URL或直接文本，内容支持Markdown格式"
+                    "description": "支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
                 },
                 "icon": {
                     "$ref": "#/definitions/i18nString",
@@ -417,11 +786,105 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "option": {
+                    "type": "array",
+                    "title": "资源包级选项配置",
+                    "description": "可选。资源包级的选项配置，为一个字符串数组，数组元素应与外层 option 配置中的键名对应。该选项生成的参数会参与到所有任务的 pipeline override 中，起到资源包级参数传递的作用",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hash": {
+                    "type": "string",
+                    "minLength": 1,
+                    "title": "资源 hash",
+                    "description": "资源校验值，通过 MaaResourceGetHash 获取。校验时机为加载 resource.path 后、加载 controller.attach_resource_path 之前"
                 }
             },
             "required": [
                 "name",
                 "path"
+            ],
+            "additionalProperties": false
+        },
+        "groupItem": {
+            "type": "object",
+            "title": "任务分组配置",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "分组唯一标识符",
+                    "description": "用作分组 ID，供 task.group 引用"
+                },
+                "label": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "显示名称",
+                    "description": "用于在用户界面中展示，支持国际化。如果未设置，则显示 name 字段的值"
+                },
+                "description": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "详细描述",
+                    "description": "帮助用户理解该分组的用途。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                },
+                "icon": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "图标路径",
+                    "description": "分组图标文件路径，相对于项目根目录"
+                },
+                "default_expand": {
+                    "type": "boolean",
+                    "title": "默认展开",
+                    "description": "💡 v2.4.0 可选。该分组在 Client 中是否默认展开",
+                    "default": true
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false
+        },
+        "settingSection": {
+            "type": "object",
+            "title": "任务设置页分区",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "分区唯一标识符",
+                    "description": "用作分区锚点与内部键"
+                },
+                "label": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "显示名称",
+                    "description": "用于在用户界面中展示，支持国际化。如果未设置，则显示 name 字段的值"
+                },
+                "description": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "详细描述",
+                    "description": "帮助用户理解该设置分区的用途。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                },
+                "icon": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "图标路径",
+                    "description": "分区图标文件路径，相对于项目根目录"
+                },
+                "option": {
+                    "type": "array",
+                    "title": "关联 option 键名",
+                    "description": "来自顶层 option 配置的有序 option 键名列表",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "default_expand": {
+                    "type": "boolean",
+                    "title": "默认展开",
+                    "description": "💡 v2.8.0 可选。该分区在 Client 中是否默认展开",
+                    "default": true
+                }
+            },
+            "required": [
+                "name"
             ],
             "additionalProperties": false
         },
@@ -432,7 +895,7 @@
                 "name": {
                     "type": "string",
                     "title": "任务唯一标识符",
-                    "description": "用作任务ID"
+                    "description": "用作任务 ID"
                 },
                 "label": {
                     "$ref": "#/definitions/i18nString",
@@ -447,23 +910,69 @@
                 "default_check": {
                     "type": "boolean",
                     "title": "默认选中",
-                    "description": "是否默认选中该任务。Client在初始化时会根据该值决定是否默认勾选该任务",
+                    "description": "是否默认选中该任务。Client 在初始化时会根据该值决定是否默认勾选该任务",
                     "default": false
                 },
                 "description": {
                     "$ref": "#/definitions/i18nString",
                     "title": "详细描述",
-                    "description": "帮助用户理解任务功能。支持文件路径、URL或直接文本，内容支持Markdown格式"
+                    "description": "帮助用户理解任务功能。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                },
+                "doc": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/i18nString"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/i18nString"
+                            }
+                        }
+                    ],
+                    "title": "任务文档",
+                    "description": "任务的详细文档说明，支持字符串或字符串数组"
+                },
+                "desc": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/i18nString"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/i18nString"
+                            }
+                        }
+                    ],
+                    "title": "任务文档",
+                    "description": "任务的详细文档说明，支持字符串或字符串数组"
                 },
                 "icon": {
                     "$ref": "#/definitions/i18nString",
                     "title": "图标路径",
                     "description": "任务图标文件路径，相对于项目根目录"
                 },
+                "group": {
+                    "type": "array",
+                    "title": "所属分组",
+                    "description": "💡 v2.4.0 可选。指定该任务所属的分组列表。数组元素应与顶层 group 配置中的 name 字段对应。若不指定，则表示该任务不属于任何显式分组",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "resource": {
                     "type": "array",
                     "title": "支持的资源包",
                     "description": "指定该任务支持的资源包列表。数组元素应与 resource 配置中的 name 字段对应。若不指定，则表示该任务在所有资源包中都可用",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "controller": {
+                    "type": "array",
+                    "title": "支持的控制器",
+                    "description": "指定该任务支持的控制器类型列表。数组元素应与 controller 配置中的 name 字段对应。若不指定，则表示该任务在所有控制器类型中都可用",
                     "items": {
                         "type": "string"
                     }
@@ -476,7 +985,7 @@
                 "option": {
                     "type": "array",
                     "title": "任务配置项",
-                    "description": "含有若干 option 对象中的键的值，Client 会根据要求让用户进行选择",
+                    "description": "包含若干 option 对象中的键的值，Client 会根据要求让用户进行选择",
                     "items": {
                         "type": "string"
                     }
@@ -488,10 +997,78 @@
             ],
             "additionalProperties": false
         },
+        "pretaskConfig": {
+            "type": "object",
+            "title": "预任务配置",
+            "description": "💡 v2.7.0 Controller 启动前执行的自定义程序配置。Client 应在创建或连接 Controller 前运行该程序；若配置 option，则将 option 取值序列化为紧凑 JSON 字符串并追加为最后一个参数",
+            "properties": {
+                "resource": {
+                    "type": "array",
+                    "title": "支持的资源包",
+                    "description": "💡 v2.8.1 可选。指定该预任务支持的资源包列表。数组元素应与 resource 配置中的 name 字段对应。若不指定，则表示该预任务在所有资源包中都可用",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "controller": {
+                    "type": "array",
+                    "title": "支持的控制器",
+                    "description": "💡 v2.8.1 可选。指定该预任务支持的控制器类型列表。数组元素应与 controller 配置中的 name 字段对应。若不指定，则表示该预任务在所有控制器类型中都可用",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "exec": {
+                    "type": "string",
+                    "title": "预任务程序路径",
+                    "description": "要执行的程序路径，可以是系统 PATH 中的可执行文件。CWD 为 interface.json 所在目录"
+                },
+                "args": {
+                    "type": "array",
+                    "title": "预任务参数",
+                    "description": "可选。固定参数数组，按顺序传递给 exec",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string",
+                    "title": "预任务唯一标识",
+                    "description": "可选。建议项目内不重复，便于 Client 在配置文件、日志中区分不同预任务；缺省时 Client 可回退到 exec"
+                },
+                "label": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "预任务显示名称",
+                    "description": "可选。Client UI 中展示的名称，支持国际化字符串。缺省时 Client 可回退到 name 或 exec"
+                },
+                "description": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "预任务详细描述",
+                    "description": "可选。Client UI 中的提示/Tooltip。支持国际化字符串、文件路径或 URL，内容支持 Markdown"
+                },
+                "icon": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "预任务图标路径",
+                    "description": "可选。Client UI 中显示的图标路径，相对于 interface.json 所在目录，支持国际化字符串"
+                },
+                "option": {
+                    "type": "array",
+                    "title": "预任务选项配置",
+                    "description": "可选。数组元素应与外层 option 配置中的键名对应。Client 会收集这些 option 的当前取值并序列化为紧凑 JSON 字符串，追加为最后一个参数；该 option 不参与 pipeline_override 合并",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "exec"
+            ],
+            "additionalProperties": false
+        },
         "agentConfig": {
             "type": "object",
             "title": "代理配置",
-            "description": "含有子进程（AgentServer）的信息",
+            "description": "包含子进程（AgentServer）的信息。💡 v2.5.0：Client 启动该子进程时应向环境注入 PI_INTERFACE_VERSION、PI_CLIENT_*、PI_VERSION、PI_CONTROLLER、PI_RESOURCE 等变量，详见 Project Interface 文档",
             "properties": {
                 "child_exec": {
                     "type": "string",
@@ -522,7 +1099,7 @@
         "interface_version": {
             "type": "number",
             "title": "接口版本号",
-            "description": "当前为 2，固定且必须设置。用于标识 ProjectInterface 协议版本",
+            "description": "当前为 2，固定且必须设置。标识 interface.json 的 JSON 结构主版本；与 PI 文档独立演进的语义化版本（如 v2.5.0 的 PI_* 环境变量约定）不同，二者不必对应",
             "const": 2
         },
         "languages": {
@@ -542,7 +1119,7 @@
         "name": {
             "type": "string",
             "title": "项目唯一标识符",
-            "description": "用作项目ID"
+            "description": "用作项目 ID"
         },
         "label": {
             "$ref": "#/definitions/i18nString",
@@ -572,7 +1149,7 @@
         "github": {
             "type": "string",
             "title": "GitHub 仓库地址",
-            "description": "项目GitHub仓库地址，用于版本更新检查和问题反馈",
+            "description": "项目 GitHub 仓库地址，用于版本更新检查和问题反馈",
             "format": "uri"
         },
         "version": {
@@ -583,27 +1160,68 @@
         "contact": {
             "$ref": "#/definitions/i18nString",
             "title": "联系方式",
-            "description": "显示在“关于”页面。支持文件路径、URL或直接文本，内容支持Markdown格式"
+            "description": "显示在「关于」页面。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
         },
         "license": {
             "$ref": "#/definitions/i18nString",
             "title": "许可证信息",
-            "description": "显示在“关于”页面。支持文件路径、URL或直接文本，内容支持Markdown格式"
+            "description": "显示在「关于」页面。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
         },
         "welcome": {
             "$ref": "#/definitions/i18nString",
             "title": "欢迎消息",
-            "description": "在用户首次使用时弹窗显示，亦可作为公告使用。支持文件路径、URL或直接文本，内容支持Markdown格式。系统会记录显示内容，当内容更新时会再次弹窗显示"
+            "description": "在用户首次使用时弹窗显示，亦可作为公告使用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式。系统会记录显示内容，当内容更新时会再次弹窗显示"
         },
         "description": {
             "$ref": "#/definitions/i18nString",
             "title": "项目描述",
-            "description": "显示在“关于”页面。支持文件路径、URL或直接文本，内容支持Markdown格式"
+            "description": "显示在「关于」页面。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+        },
+        "telemetry": {
+            "type": "object",
+            "title": "匿名遥测配置",
+            "description": "💡 v2.9.0 可选。匿名遥测（数据埋点）配置容器，用于向资源作者自己的遥测平台上报崩溃与任务运行统计。并非所有 Client 都会支持。未配置时不进行任何遥测",
+            "properties": {
+                "sentry": {
+                    "type": "object",
+                    "title": "Sentry 遥测配置",
+                    "description": "基于 Sentry 的遥测配置",
+                    "properties": {
+                        "dsn": {
+                            "type": "string",
+                            "title": "Sentry DSN",
+                            "description": "Sentry 项目的 DSN。必填；缺省或为空字符串时不启用 Sentry 遥测"
+                        },
+                        "tracing": {
+                            "type": "boolean",
+                            "title": "是否启用性能 / 事务上报",
+                            "description": "任务开始、结束及各子任务结果以事务 / Span 形式上报。默认 true。关闭后仅上报崩溃 / 错误"
+                        },
+                        "traces_sample_rate": {
+                            "type": "number",
+                            "title": "事务采样率",
+                            "description": "取值 0~1，默认 1.0。用户量较大时可调低以控制 Sentry 配额，但统计将变为抽样",
+                            "minimum": 0,
+                            "maximum": 1
+                        },
+                        "environment": {
+                            "type": "string",
+                            "title": "环境标签",
+                            "description": "如 production、beta，用于在 Sentry 中区分。缺省由 Client 决定"
+                        }
+                    },
+                    "required": [
+                        "dsn"
+                    ],
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
         },
         "controller": {
             "type": "array",
             "title": "控制器配置",
-            "description": "为一个对象数组，含有预设的控制器信息",
+            "description": "为一个对象数组，包含预设的控制器信息",
             "items": {
                 "$ref": "#/definitions/controllerItem"
             }
@@ -611,18 +1229,55 @@
         "resource": {
             "type": "array",
             "title": "资源配置",
-            "description": "为一个对象数组，含有资源加载的信息",
+            "description": "为一个对象数组，包含资源加载的信息",
             "items": {
                 "$ref": "#/definitions/resourceItem"
             }
         },
+        "group": {
+            "type": "array",
+            "title": "任务分组配置",
+            "description": "💡 v2.4.0 可选。为一个对象数组，用于声明任务分组及其展示属性",
+            "items": {
+                "$ref": "#/definitions/groupItem"
+            }
+        },
+        "pretask": {
+            "description": "💡 v2.7.0 可选。Controller 启动前执行的预任务配置。若配置 option，Client 应将 option 取值序列化为最后一个参数",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/pretaskConfig"
+                },
+                {
+                    "type": "array",
+                    "title": "预任务配置数组",
+                    "description": "多个预任务配置。Client 应在 Controller 启动前按数组顺序执行",
+                    "items": {
+                        "$ref": "#/definitions/pretaskConfig"
+                    }
+                }
+            ]
+        },
         "agent": {
-            "$ref": "#/definitions/agentConfig"
+            "description": "💡 v2.5.0：启动各子进程时 Client 应注入 PI_* 环境变量，详见 Project Interface 文档",
+            "oneOf": [
+                {
+                    "$ref": "#/definitions/agentConfig"
+                },
+                {
+                    "type": "array",
+                    "title": "代理配置数组",
+                    "description": "多个子进程（AgentServer）的配置。💡 v2.5.0：每个子进程启动时均应获得 PI_* 环境变量",
+                    "items": {
+                        "$ref": "#/definitions/agentConfig"
+                    }
+                }
+            ]
         },
         "task": {
             "type": "array",
             "title": "任务配置",
-            "description": "为一个对象数组，含有可执行任务的信息",
+            "description": "为一个对象数组，包含可执行任务的信息",
             "items": {
                 "$ref": "#/definitions/taskItem"
             }
@@ -630,9 +1285,100 @@
         "option": {
             "type": "object",
             "title": "配置项定义",
-            "description": "为一个对象映射，含有配置项的信息",
+            "description": "为一个对象映射，包含配置项的信息",
             "additionalProperties": {
                 "$ref": "#/definitions/optionDefinition"
+            }
+        },
+        "global_option": {
+            "type": "array",
+            "title": "全局选项配置",
+            "description": "💡 v2.3.0 可选。全局选项配置，为一个字符串数组，数组元素应与 option 配置中的键名对应。该选项生成的参数会参与到所有任务的 pipeline override 中，无论用户选择了什么资源包或控制器",
+            "items": {
+                "type": "string"
+            }
+        },
+        "setting": {
+            "type": "array",
+            "title": "任务设置页 UI 声明",
+            "description": "💡 v2.8.0 可选。任务设置页 UI 声明，供 Client 渲染全局任务配置专用设置区域。Client 应将其视为展示层元数据",
+            "items": {
+                "$ref": "#/definitions/settingSection"
+            }
+        },
+        "import": {
+            "type": "array",
+            "title": "导入其他 PI 文件",
+            "description": "可选。导入其他 PI 文件的路径数组。文件相对路径为 interface.json 同目录下的相对路径。支持导入这些文件中的 task、option、preset（💡 v2.3.0）、group（💡 v2.4.0）、pretask（💡 v2.7.0）、global_option 与 setting（💡 v2.8.0）字段",
+            "items": {
+                "type": "string"
+            }
+        },
+        "preset": {
+            "type": "array",
+            "title": "预设配置",
+            "description": "💡 v2.3.0 可选。预设配置，为一个对象数组。每个预设是一套预定义的任务勾选状态与选项值的快照，用户可一键应用，快速切换不同使用场景",
+            "items": {
+                "type": "object",
+                "title": "预设项",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "预设唯一标识符",
+                        "description": "用作预设 ID"
+                    },
+                    "label": {
+                        "$ref": "#/definitions/i18nString",
+                        "title": "显示名称",
+                        "description": "用于在用户界面中展示，支持国际化。如果未设置，则显示 name 字段的值"
+                    },
+                    "description": {
+                        "$ref": "#/definitions/i18nString",
+                        "title": "详细描述",
+                        "description": "帮助用户理解该预设的适用场景。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                    },
+                    "icon": {
+                        "$ref": "#/definitions/i18nString",
+                        "title": "图标路径",
+                        "description": "预设图标文件路径，相对于项目根目录"
+                    },
+                    "task": {
+                        "type": "array",
+                        "title": "预设任务配置",
+                        "description": "预设包含的任务配置列表",
+                        "items": {
+                            "type": "object",
+                            "title": "预设任务项",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "title": "任务名称",
+                                    "description": "必须。与顶层 task[].name 对应的任务名称"
+                                },
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "是否启用",
+                                    "description": "可选，默认 true。该任务在预设中是否勾选",
+                                    "default": true
+                                },
+                                "option": {
+                                    "type": "object",
+                                    "title": "任务选项预设值",
+                                    "description": "可选。该任务各配置项的预设值，键为顶层 option 中的键名。select/switch 类型填 case.name 字符串，checkbox 类型填 case.name 数组，input 类型填 record<string, string>",
+                                    "additionalProperties": true
+                                }
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "additionalProperties": false
             }
         }
     },
@@ -640,8 +1386,7 @@
         "interface_version",
         "name",
         "controller",
-        "resource",
-        "task"
+        "resource"
     ],
     "additionalProperties": false
 }

--- a/deps/tools/interface_config.schema.json
+++ b/deps/tools/interface_config.schema.json
@@ -13,7 +13,12 @@
                 "type": {
                     "title": "控制器类型",
                     "type": "string",
-                    "enum": ["Adb", "Win32"]
+                    "enum": [
+                        "Adb",
+                        "Win32",
+                        "PlayCover",
+                        "Linux"
+                    ]
                 }
             }
         },
@@ -38,6 +43,42 @@
         "win32": {
             "title": "Win32配置",
             "type": "object"
+        },
+        "playcover": {
+            "title": "PlayCover配置",
+            "type": "object",
+            "properties": {
+                "address": {
+                    "title": "服务地址",
+                    "type": "string"
+                },
+                "uuid": {
+                    "title": "Bundle Identifier",
+                    "type": "string"
+                }
+            }
+        },
+        "linux": {
+            "title": "Linux配置",
+            "type": "object",
+            "properties": {
+                "wlr_socket_path": {
+                    "title": "Wayland Socket 路径",
+                    "type": "string"
+                },
+                "uinput_screen_width": {
+                    "title": "UInput 屏幕宽度（像素）",
+                    "type": "integer"
+                },
+                "uinput_screen_height": {
+                    "title": "UInput 屏幕高度（像素）",
+                    "type": "integer"
+                },
+                "eis_socket_path": {
+                    "title": "EIS socket 路径",
+                    "type": "string"
+                }
+            }
         },
         "resource": {
             "title": "激活的资源",

--- a/deps/tools/interface_import.schema.json
+++ b/deps/tools/interface_import.schema.json
@@ -1,0 +1,531 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "MaaFramework Project Interface Task File",
+    "description": "MaaFramework 项目接口导入的任务文件 JSON Schema，用于 interface.json 的 import 字段引用的文件",
+    "type": "object",
+    "definitions": {
+        "i18nString": {
+            "type": "string",
+            "description": "支持国际化的字符串，以 $ 开头表示从翻译文件中读取"
+        },
+        "pipelineOverride": {
+            "type": "object",
+            "title": "Pipeline 覆盖配置",
+            "description": "用于覆盖已加载资源中的 pipeline 配置",
+            "additionalProperties": true
+        },
+        "caseItem": {
+            "type": "object",
+            "title": "选项",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "选项唯一标识符",
+                    "description": "用作选项 ID"
+                },
+                "label": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "显示名称",
+                    "description": "用于在用户界面中展示，支持国际化。如果未设置，则显示 name 字段的值"
+                },
+                "description": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "详细描述",
+                    "description": "支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                },
+                "icon": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "图标路径",
+                    "description": "选项图标文件路径，相对于项目根目录"
+                },
+                "option": {
+                    "type": "array",
+                    "title": "子配置项列表",
+                    "description": "只有当用户选中当前选项时，才会显示这些子配置项。这些子配置项同样放在外层的 option 中定义，支持无限嵌套",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "pipeline_override": {
+                    "$ref": "#/definitions/pipelineOverride",
+                    "title": "Pipeline 覆盖",
+                    "description": "在选项激活时生效的 pipeline 配置覆盖"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false
+        },
+        "inputItem": {
+            "type": "object",
+            "title": "输入字段",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "输入字段唯一标识符",
+                    "description": "用作输入字段 ID"
+                },
+                "label": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "显示名称",
+                    "description": "用于在用户界面中展示，支持国际化。如果未设置，则显示 name 字段的值"
+                },
+                "description": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "详细描述",
+                    "description": "帮助用户理解输入要求。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                },
+                "default": {
+                    "type": "string",
+                    "title": "默认值",
+                    "description": "输入字段的默认值"
+                },
+                "pipeline_type": {
+                    "type": "string",
+                    "title": "Pipeline 数据类型",
+                    "description": "输入字段在 pipeline_override 中的数据类型，用于类型转换",
+                    "enum": [
+                        "string",
+                        "int",
+                        "bool"
+                    ]
+                },
+                "verify": {
+                    "type": "string",
+                    "title": "校验正则表达式",
+                    "description": "用于校验用户输入是否合法的正则表达式"
+                },
+                "pattern_msg": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "校验错误信息",
+                    "description": "正则校验用户输入错误时显示的信息"
+                }
+            },
+            "required": [
+                "name"
+            ],
+            "additionalProperties": false
+        },
+        "optionDefinition": {
+            "type": "object",
+            "title": "配置项定义",
+            "oneOf": [
+                {
+                    "title": "inputOption",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "const": "input",
+                            "description": "用户输入框，允许用户手动输入内容"
+                        },
+                        "label": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "显示标签",
+                            "description": "用于在用户界面中展示，支持国际化"
+                        },
+                        "description": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "详细描述",
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                        },
+                        "icon": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "图标路径",
+                            "description": "配置项图标文件路径，相对于项目根目录"
+                        },
+                        "controller": {
+                            "type": "array",
+                            "title": "适用的控制器",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的控制器类型列表",
+                            "items": { "type": "string" }
+                        },
+                        "resource": {
+                            "type": "array",
+                            "title": "适用的资源包",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的资源包列表",
+                            "items": { "type": "string" }
+                        },
+                        "inputs": {
+                            "type": "array",
+                            "title": "输入配置",
+                            "description": "定义用户可输入的字段",
+                            "items": {
+                                "$ref": "#/definitions/inputItem"
+                            }
+                        },
+                        "pipeline_override": {
+                            "$ref": "#/definitions/pipelineOverride",
+                            "title": "Pipeline 覆盖模板",
+                            "description": "支持使用「名称」格式引用输入字段的值"
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "inputs"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "title": "selectOption",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "const": "select",
+                            "description": "下拉选项框，用户从预定义的选项中选择"
+                        },
+                        "label": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "显示标签",
+                            "description": "用于在用户界面中展示，支持国际化"
+                        },
+                        "description": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "详细描述",
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                        },
+                        "icon": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "图标路径",
+                            "description": "配置项图标文件路径，相对于项目根目录"
+                        },
+                        "controller": {
+                            "type": "array",
+                            "title": "适用的控制器",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的控制器类型列表",
+                            "items": { "type": "string" }
+                        },
+                        "resource": {
+                            "type": "array",
+                            "title": "适用的资源包",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的资源包列表",
+                            "items": { "type": "string" }
+                        },
+                        "cases": {
+                            "type": "array",
+                            "title": "可选项列表",
+                            "items": {
+                                "$ref": "#/definitions/caseItem"
+                            }
+                        },
+                        "default_case": {
+                            "type": "string",
+                            "title": "默认选项",
+                            "description": "默认选项名称"
+                        }
+                    },
+                    "required": [
+                        "cases"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "title": "checkboxOption",
+                    "type": "object",
+                    "description": "💡 v2.3.0 多选框，用户从预定义的选项中选择多个",
+                    "properties": {
+                        "type": {
+                            "const": "checkbox",
+                            "description": "💡 v2.3.0 多选框，用户从预定义的选项中选择多个"
+                        },
+                        "label": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "显示标签",
+                            "description": "用于在用户界面中展示，支持国际化"
+                        },
+                        "description": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "详细描述",
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                        },
+                        "icon": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "图标路径",
+                            "description": "配置项图标文件路径，相对于项目根目录"
+                        },
+                        "controller": {
+                            "type": "array",
+                            "title": "适用的控制器",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的控制器类型列表",
+                            "items": { "type": "string" }
+                        },
+                        "resource": {
+                            "type": "array",
+                            "title": "适用的资源包",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的资源包列表",
+                            "items": { "type": "string" }
+                        },
+                        "cases": {
+                            "type": "array",
+                            "title": "可选项列表",
+                            "description": "用户可同时选中多个 case，所有被选中的 case 的 pipeline_override 会按照 cases 数组中的定义顺序依次合并生效",
+                            "items": {
+                                "$ref": "#/definitions/caseItem"
+                            }
+                        },
+                        "default_case": {
+                            "type": "array",
+                            "title": "默认选中项",
+                            "description": "💡 v2.3.0 默认选中的选项名称数组，Client 使用该值作为多选框的初始选中值",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "required": [
+                        "type",
+                        "cases"
+                    ],
+                    "additionalProperties": false
+                },
+                {
+                    "title": "switchOption",
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "const": "switch",
+                            "description": "选择框，Yes or No"
+                        },
+                        "label": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "显示标签",
+                            "description": "用于在用户界面中展示，支持国际化"
+                        },
+                        "description": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "详细描述",
+                            "description": "帮助用户理解配置项的作用。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                        },
+                        "icon": {
+                            "$ref": "#/definitions/i18nString",
+                            "title": "图标路径",
+                            "description": "配置项图标文件路径，相对于项目根目录"
+                        },
+                        "controller": {
+                            "type": "array",
+                            "title": "适用的控制器",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的控制器类型列表",
+                            "items": { "type": "string" }
+                        },
+                        "resource": {
+                            "type": "array",
+                            "title": "适用的资源包",
+                            "description": "💡 v2.3.0 可选。指定该配置项适用的资源包列表",
+                            "items": { "type": "string" }
+                        },
+                        "cases": {
+                            "type": "array",
+                            "title": "可选项列表",
+                            "description": "仅支持两个 cases。case.name 应为 Yes/yes/Y/y 或 No/no/N/n 之一，建议使用 Yes 和 No",
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "items": {
+                                "$ref": "#/definitions/caseItem"
+                            }
+                        },
+                        "default_case": {
+                            "type": "string",
+                            "title": "默认选项",
+                            "description": "默认选项名称，应为 Yes 或 No"
+                        }
+                    },
+                    "required": [
+                        "cases"
+                    ],
+                    "additionalProperties": false
+                }
+            ]
+        },
+        "taskItem": {
+            "type": "object",
+            "title": "任务配置",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "任务唯一标识符",
+                    "description": "用作任务 ID"
+                },
+                "label": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "显示名称",
+                    "description": "用于在用户界面中展示，支持国际化。如果未设置，则显示 name 字段的值"
+                },
+                "entry": {
+                    "type": "string",
+                    "title": "任务入口",
+                    "description": "为 pipeline 中 Task 的名称"
+                },
+                "default_check": {
+                    "type": "boolean",
+                    "title": "默认选中",
+                    "description": "是否默认选中该任务。Client 在初始化时会根据该值决定是否默认勾选该任务",
+                    "default": false
+                },
+                "description": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "详细描述",
+                    "description": "帮助用户理解任务功能。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                },
+                "doc": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/i18nString"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/i18nString"
+                            }
+                        }
+                    ],
+                    "title": "任务文档",
+                    "description": "任务的详细文档说明，支持字符串或字符串数组"
+                },
+                "desc": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/i18nString"
+                        },
+                        {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/i18nString"
+                            }
+                        }
+                    ],
+                    "title": "任务文档",
+                    "description": "任务的详细文档说明，支持字符串或字符串数组"
+                },
+                "icon": {
+                    "$ref": "#/definitions/i18nString",
+                    "title": "图标路径",
+                    "description": "任务图标文件路径，相对于项目根目录"
+                },
+                "group": {
+                    "type": "array",
+                    "title": "所属分组",
+                    "description": "💡 v2.4.0 可选。指定该任务所属的分组列表。数组元素应与顶层 group 配置中的 name 字段对应。若不指定，则表示该任务不属于任何显式分组",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "resource": {
+                    "type": "array",
+                    "title": "支持的资源包",
+                    "description": "指定该任务支持的资源包列表。数组元素应与 resource 配置中的 name 字段对应。若不指定，则表示该任务在所有资源包中都可用",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "controller": {
+                    "type": "array",
+                    "title": "支持的控制器",
+                    "description": "指定该任务支持的控制器类型列表。数组元素应与 controller 配置中的 name 字段对应。若不指定，则表示该任务在所有控制器类型中都可用",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "pipeline_override": {
+                    "$ref": "#/definitions/pipelineOverride",
+                    "title": "Pipeline 覆盖",
+                    "description": "执行任务时会覆盖已加载的资源"
+                },
+                "option": {
+                    "type": "array",
+                    "title": "任务配置项",
+                    "description": "包含若干 option 对象中的键的值，Client 会根据要求让用户进行选择",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": [
+                "name",
+                "entry"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "properties": {
+        "task": {
+            "type": "array",
+            "title": "任务配置",
+            "description": "为一个对象数组，包含可执行任务的信息",
+            "items": {
+                "$ref": "#/definitions/taskItem"
+            }
+        },
+        "option": {
+            "type": "object",
+            "title": "配置项定义",
+            "description": "为一个对象映射，包含配置项的信息",
+            "additionalProperties": {
+                "$ref": "#/definitions/optionDefinition"
+            }
+        },
+        "preset": {
+            "type": "array",
+            "title": "预设配置",
+            "description": "💡 v2.3.0 可选。预设配置，为一个对象数组。每个预设是一套预定义的任务勾选状态与选项值的快照，用户可一键应用，快速切换不同使用场景",
+            "items": {
+                "type": "object",
+                "title": "预设项",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "title": "预设唯一标识符",
+                        "description": "用作预设 ID"
+                    },
+                    "label": {
+                        "$ref": "#/definitions/i18nString",
+                        "title": "显示名称",
+                        "description": "用于在用户界面中展示，支持国际化。如果未设置，则显示 name 字段的值"
+                    },
+                    "description": {
+                        "$ref": "#/definitions/i18nString",
+                        "title": "详细描述",
+                        "description": "帮助用户理解该预设的适用场景。支持文件路径、URL 或直接文本，内容支持 Markdown 格式"
+                    },
+                    "icon": {
+                        "$ref": "#/definitions/i18nString",
+                        "title": "图标路径",
+                        "description": "预设图标文件路径，相对于项目根目录"
+                    },
+                    "task": {
+                        "type": "array",
+                        "title": "预设任务配置",
+                        "description": "预设包含的任务配置列表",
+                        "items": {
+                            "type": "object",
+                            "title": "预设任务项",
+                            "properties": {
+                                "name": {
+                                    "type": "string",
+                                    "title": "任务名称",
+                                    "description": "必须。与顶层 task[].name 对应的任务名称"
+                                },
+                                "enabled": {
+                                    "type": "boolean",
+                                    "title": "是否启用",
+                                    "description": "可选，默认 true。该任务在预设中是否勾选",
+                                    "default": true
+                                },
+                                "option": {
+                                    "type": "object",
+                                    "title": "任务选项预设值",
+                                    "description": "可选。该任务各配置项的预设值，键为顶层 option 中的键名。select/switch 类型填 case.name 字符串，checkbox 类型填 case.name 数组，input 类型填 record<string, string>",
+                                    "additionalProperties": true
+                                }
+                            },
+                            "required": ["name"],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "required": ["name"],
+                "additionalProperties": false
+            }
+        }
+    },
+    "additionalProperties": false
+}

--- a/deps/tools/pipeline.schema.json
+++ b/deps/tools/pipeline.schema.json
@@ -17,13 +17,15 @@
             "$comment": "若要使用该拓展模式，请在下面文件中编写，编写方法类似 ActionV2",
             "$ref": "./custom.action.schema.json"
         },
-        "$comments": [
-            "如何编写 pipeline schema",
-            "1. 添加属性字段需要给出 title 、 description 、 $ref ， $ref 优先使用或新增基础类型，能不写就不要写 default 。",
-            "2. 基础类型以 json 开头，需要给出 default 。",
-            "3. 专有类型如 SwipeListItem ，需要给出 unevaluatedProperties 。",
-            "4. 属性类型如果有 required ，请在 V2 中加入 TypeWithDependent 。"
-        ],
+        "$comments": {
+            "如何编写 pipeline schema": [
+                "1. 添加属性字段需要给出 title 、 description 、 $ref，",
+                "   $ref 优先使用或新增基础类型，如果属性字段的默认值与基础类型相同，则不要写 default 。",
+                "2. 基础类型以 json 开头，需要给出 default 。",
+                "3. 专有类型如 SwipeListItem ，需要给出 unevaluatedProperties 。",
+                "4. 属性类型如果有 required ，请在 V2 中加入 TypeWithDependent 。"
+            ]
+        },
         "jsonCode": {
             "patternProperties": {
                 ".*_code$|^code$": {
@@ -35,7 +37,7 @@
         },
         "jsonDocument": {
             "patternProperties": {
-                ".*_doc$|^doc$": {
+                ".*_doc$|^doc$|.*_desc$|^desc$": {
                     "title": "Document Property",
                     "description": "文档 | 该节点属性的文档说明。",
                     "type": "string",
@@ -305,6 +307,23 @@
             ],
             "default": []
         },
+        "jsonStringOrListOrMap": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "$ref": "#/$defs/jsonStringList"
+                },
+                {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "default": {}
+        },
         "NodeAttr": {
             "type": "object",
             "properties": {
@@ -444,6 +463,47 @@
                 0
             ]
         },
+        "jsonRectList": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/jsonRect"
+            },
+            "default": []
+        },
+        "jsonRectOrList": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/jsonRect"
+                },
+                {
+                    "$ref": "#/$defs/jsonRectList"
+                }
+            ],
+            "default": [
+                0,
+                0,
+                0,
+                0
+            ]
+        },
+        "jsonUInt32List": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/jsonUInt32"
+            },
+            "default": []
+        },
+        "jsonUInt32OrList": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/jsonUInt32"
+                },
+                {
+                    "$ref": "#/$defs/jsonUInt32List"
+                }
+            ],
+            "default": 0
+        },
         "jsonPoint": {
             "type": "array",
             "items": {
@@ -505,9 +565,6 @@
             "default": true
         },
         "TypeWithDependent": {
-            "properties": {
-                "type": "string"
-            },
             "anyOf": [
                 {
                     "required": [
@@ -523,7 +580,20 @@
         },
         "DirectHit": {
             "type": "object",
-            "properties": {}
+            "properties": {
+                "roi": {
+                    "title": "ROI Property",
+                    "description": "识别区域坐标。可选，默认 [0, 0, 0, 0] ，即全屏。",
+                    "$ref": "#/$defs/jsonRoi",
+                    "markdownDescription": "*array<int, 4>* | *string*\n\n识别区域坐标。可选，默认 [0, 0, 0, 0] ，即全屏。\n\n- *array<int, 4>*: 识别区域坐标，[x, y, w, h]，若希望全屏可设为 [0, 0, 0, 0] 。\n\n- *string*: 填写节点名，在之前执行过的某节点识别到的目标范围内识别。也支持 `[Anchor]锚点名` 格式引用锚点对应的节点。若引用的前置节点或锚点识别结果为空，则视为识别失败。"
+                },
+                "roi_offset": {
+                    "title": "ROI Offset Property",
+                    "description": "在 `roi` 的基础上额外移动再作为范围，四个值分别相加。可选，默认 [0, 0, 0, 0] 。",
+                    "$ref": "#/$defs/jsonRect",
+                    "markdownDescription": "*array<int, 4>*\n\n在 `roi` 的基础上额外移动再作为范围，四个值分别相加。可选，默认 [0, 0, 0, 0] 。"
+                }
+            }
         },
         "DirectHitV1": {
             "properties": {
@@ -557,7 +627,7 @@
                     "title": "ROI Property",
                     "description": "识别区域坐标。可选，默认 [0, 0, 0, 0] ，即全屏。",
                     "$ref": "#/$defs/jsonRoi",
-                    "markdownDescription": "*array<int, 4>* | *string*\n\n识别区域坐标。可选，默认 [0, 0, 0, 0] ，即全屏。\n\n- *array<int, 4>*: 识别区域坐标，[x, y, w, h]，若希望全屏可设为 [0, 0, 0, 0] 。\n\n- *string*: 填写节点名，在之前执行过的某节点识别到的目标范围内识别。"
+                    "markdownDescription": "*array<int, 4>* | *string*\n\n识别区域坐标。可选，默认 [0, 0, 0, 0] ，即全屏。\n\n- *array<int, 4>*: 识别区域坐标，[x, y, w, h]，若希望全屏可设为 [0, 0, 0, 0] 。\n\n- *string*: 填写节点名，在之前执行过的某节点识别到的目标范围内识别。也支持 `[Anchor]锚点名` 格式引用锚点对应的节点。若引用的前置节点或锚点识别结果为空，则视为识别失败。"
                 },
                 "roi_offset": {
                     "title": "ROI Offset Property",
@@ -941,9 +1011,9 @@
                 },
                 "expected": {
                     "title": "Expected Property",
-                    "description": "期望的结果，支持正则。必选。",
+                    "description": "期望的结果，支持正则。可选，默认匹配所有结果。",
                     "$ref": "#/$defs/jsonRegexOrList",
-                    "markdownDescription": "*string* | *list<string, >*\n\n期望的结果，支持正则。必选。"
+                    "markdownDescription": "*string* | *list<string, >*\n\n期望的结果，支持正则。可选，默认匹配所有结果。"
                 },
                 "threshold": {
                     "title": "Threshold Property",
@@ -989,20 +1059,14 @@
                     "description": "模型 **文件夹** 路径。使用 `model/ocr` 文件夹的相对路径。可选，默认为空。",
                     "type": "string",
                     "markdownDescription": "*string*\n\n模型 **文件夹** 路径。使用 `model/ocr` 文件夹的相对路径。可选，默认为空。\n\n若为空，则为 `model/ocr` 根目录下的模型文件。\n\n文件夹中需要包含 `rec.onnx`, `det.onnx`, `keys.txt` 三个文件。"
-                }
-            },
-            "anyOf": [
-                {
-                    "required": [
-                        "expected"
-                    ]
                 },
-                {
-                    "required": [
-                        "expected_code"
-                    ]
+                "color_filter": {
+                    "title": "Color Filter Property",
+                    "description": "颜色过滤。填写某个 ColorMatch 节点名，先使用该节点的颜色参数对图像进行二值化，再送入 OCR 识别。可选，默认为空。",
+                    "type": "string",
+                    "markdownDescription": "*string*\n\n颜色过滤。填写某个 `ColorMatch` 节点名，先使用该节点的颜色参数（`method`、`lower`、`upper`）对图像进行二值化，再送入 OCR 识别。可选，默认为空。\n\n仅使用该节点的颜色二值化逻辑，不依赖其 `count`、`order_by` 等结果参数。\n\n设置了该字段的 OCR 节点不参与 batch 优化。"
                 }
-            ]
+            }
         },
         "OcrV1": {
             "properties": {
@@ -1062,9 +1126,9 @@
                 },
                 "expected": {
                     "title": "Expected Property",
-                    "description": "期望的分类下标。必选。",
+                    "description": "期望的分类下标。可选，默认匹配所有结果。",
                     "$ref": "#/$defs/jsonInt32OrList",
-                    "markdownDescription": "*int* | *list<int, >*\n\n期望的分类下标。必选。"
+                    "markdownDescription": "*int* | *list<int, >*\n\n期望的分类下标。可选，默认匹配所有结果。"
                 },
                 "order_by": {
                     "title": "Order By Property",
@@ -1089,26 +1153,12 @@
             "anyOf": [
                 {
                     "required": [
-                        "model",
-                        "expected"
+                        "model"
                     ]
                 },
                 {
                     "required": [
-                        "model_code",
-                        "expected_code"
-                    ]
-                },
-                {
-                    "required": [
-                        "model_code",
-                        "expected"
-                    ]
-                },
-                {
-                    "required": [
-                        "model",
-                        "expected_code"
+                        "model_code"
                     ]
                 }
             ]
@@ -1167,13 +1217,13 @@
                     "title": "Model Property",
                     "description": "模型文件路径。使用 `model/detect` 文件夹的相对路径。必选。",
                     "type": "string",
-                    "markdownDescription": "*string*\n\n模型文件路径。使用 `model/detect` 文件夹的相对路径。必选。\n\n目前支持 YoloV8 ONNX 模型，其他同样输入输出的 Yolo 模型理论上也可以支持，但未经测试。\n\n训练参考 [NNDetect 食谱](https://github.com/MaaXYZ/MaaNeuralNetworkCookbook/tree/main/NeuralNetworkDetect)。"
+                    "markdownDescription": "*string*\n\n模型文件路径。使用 `model/detect` 文件夹的相对路径。必选。\n\n目前支持由 YOLOv8 和 YOLOv11 导出的 ONNX 格式的模型，其他同样输入输出的 Yolo 模型理论上也可以支持，但未经测试。\n\n训练参考 [NNDetect 食谱](https://github.com/MaaXYZ/MaaNeuralNetworkCookbook/tree/main/NeuralNetworkDetect)。"
                 },
                 "expected": {
                     "title": "Expected Property",
-                    "description": "期望的分类下标。必选。",
+                    "description": "期望的分类下标。可选，默认匹配所有结果。",
                     "$ref": "#/$defs/jsonInt32OrList",
-                    "markdownDescription": "*int* | *list<int, >*\n\n期望的分类下标。"
+                    "markdownDescription": "*int* | *list<int, >*\n\n期望的分类下标。可选，默认匹配所有结果。"
                 },
                 "threshold": {
                     "title": "Threshold Property",
@@ -1206,26 +1256,12 @@
             "anyOf": [
                 {
                     "required": [
-                        "model",
-                        "expected"
+                        "model"
                     ]
                 },
                 {
                     "required": [
-                        "model_code",
-                        "expected_code"
-                    ]
-                },
-                {
-                    "required": [
-                        "model_code",
-                        "expected"
-                    ]
-                },
-                {
-                    "required": [
-                        "model",
-                        "expected_code"
+                        "model_code"
                     ]
                 }
             ]
@@ -1252,6 +1288,138 @@
                     "allOf": [
                         {
                             "$ref": "#/$defs/NeuralNetworkDetect"
+                        },
+                        {
+                            "$ref": "#/$defs/jsonComments"
+                        }
+                    ]
+                }
+            },
+            "dependentSchemas": {
+                "type": {
+                    "$ref": "#/$defs/TypeWithDependent"
+                }
+            }
+        },
+        "SubRecognitionInline": {
+            "type": "object",
+            "properties": {
+                "sub_name": {
+                    "title": "Sub Name Property",
+                    "description": "子识别别名。可选。后续子识别可通过 `roi: sub_name` 引用之前子识别的 `filtered` 作为 ROI；同名以最后一个为准；仅当前节点内有效。（仅支持 `And`）",
+                    "type": "string",
+                    "markdownDescription": "*string*\n\n子识别别名。可选。\n\n后续子识别可通过 `roi: sub_name` 引用之前子识别的 `filtered` 作为 ROI；同名以最后一个为准；仅当前节点内有效。（仅支持 `And`）"
+                }
+            }
+        },
+        "SubRecognition": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "description": "节点名称引用。运行时使用该节点的识别算法和参数。"
+                },
+                {
+                    "$ref": "#/$defs/SubRecognitionInline"
+                }
+            ]
+        },
+        "And": {
+            "type": "object",
+            "properties": {
+                "all_of": {
+                    "title": "All Of Property",
+                    "description": "子识别列表。所有子识别都命中才算成功。必选。支持节点名称引用或内联定义。",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/SubRecognition"
+                    },
+                    "markdownDescription": "*list<string | object, >*\n\n子识别列表。所有子识别都命中才算成功。必选。\n\n列表元素可以是：\n- 字符串：节点名称引用，运行时使用该节点的识别算法和参数\n- 对象：内联识别定义，写法与普通节点的 `recognition` 一致（兼容 v1/v2，允许混用）"
+                },
+                "box_index": {
+                    "title": "Box Index Property",
+                    "description": "指定输出哪个子识别的识别框（box）作为当前节点的识别框。可选，默认 0。",
+                    "$ref": "#/$defs/jsonNInt32",
+                    "markdownDescription": "*int*\n\n指定输出哪个子识别的识别框（box）作为当前节点的识别框。可选，默认 0 。\n\n需要满足 `0 <= box_index < all_of.size` 。"
+                }
+            },
+            "required": [
+                "all_of"
+            ]
+        },
+        "AndV1": {
+            "properties": {
+                "recognition": {
+                    "const": "And"
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "#/$defs/And"
+                }
+            ]
+        },
+        "AndV2": {
+            "properties": {
+                "type": {
+                    "const": "And"
+                },
+                "param": {
+                    "unevaluatedProperties": false,
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/And"
+                        },
+                        {
+                            "$ref": "#/$defs/jsonComments"
+                        }
+                    ]
+                }
+            },
+            "dependentSchemas": {
+                "type": {
+                    "$ref": "#/$defs/TypeWithDependent"
+                }
+            }
+        },
+        "Or": {
+            "type": "object",
+            "properties": {
+                "any_of": {
+                    "title": "Any Of Property",
+                    "description": "子识别列表。命中第一个即成功，后续不再识别。必选。支持节点名称引用或内联定义。",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/SubRecognition"
+                    },
+                    "markdownDescription": "*list<string | object, >*\n\n子识别列表。命中第一个即成功，后续不再识别。必选。\n\n列表元素可以是：\n- 字符串：节点名称引用，运行时使用该节点的识别算法和参数\n- 对象：内联识别定义，写法与普通节点的 `recognition` 一致（兼容 v1/v2，允许混用）"
+                }
+            },
+            "required": [
+                "any_of"
+            ]
+        },
+        "OrV1": {
+            "properties": {
+                "recognition": {
+                    "const": "Or"
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "#/$defs/Or"
+                }
+            ]
+        },
+        "OrV2": {
+            "properties": {
+                "type": {
+                    "const": "Or"
+                },
+                "param": {
+                    "unevaluatedProperties": false,
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/Or"
                         },
                         {
                             "$ref": "#/$defs/jsonComments"
@@ -1382,6 +1550,8 @@
                 "OCR",
                 "NeuralNetworkClassify",
                 "NeuralNetworkDetect",
+                "And",
+                "Or",
                 "Custom"
             ]
         },
@@ -1710,6 +1880,32 @@
                     }
                 },
                 {
+                    "label": "AndV1",
+                    "body": "^ \"And\",\n\"all_of\": []"
+                },
+                {
+                    "label": "AndV2",
+                    "body": {
+                        "type": "And",
+                        "param": {
+                            "all_of": []
+                        }
+                    }
+                },
+                {
+                    "label": "OrV1",
+                    "body": "^ \"Or\",\n\"any_of\": []"
+                },
+                {
+                    "label": "OrV2",
+                    "body": {
+                        "type": "Or",
+                        "param": {
+                            "any_of": []
+                        }
+                    }
+                },
+                {
                     "label": "CustomRecognitionV1",
                     "body": "^ \"Custom\",\n\"custom_recognition\": \"\""
                 },
@@ -1754,6 +1950,12 @@
                 },
                 {
                     "$ref": "#/$defs/NeuralNetworkDetectV1"
+                },
+                {
+                    "$ref": "#/$defs/AndV1"
+                },
+                {
+                    "$ref": "#/$defs/OrV1"
                 },
                 {
                     "$ref": "#/$defs/CustomRecognitionV1"
@@ -1802,6 +2004,12 @@
                         },
                         {
                             "$ref": "#/$defs/NeuralNetworkDetectV2"
+                        },
+                        {
+                            "$ref": "#/$defs/AndV2"
+                        },
+                        {
+                            "$ref": "#/$defs/OrV2"
                         },
                         {
                             "$ref": "#/$defs/CustomRecognitionV2"
@@ -1885,7 +2093,7 @@
                     "title": "Target Property",
                     "description": "点击目标的位置。可选，默认 true 。",
                     "$ref": "#/$defs/jsonTarget",
-                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>*\n\n点击目标的位置。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。"
+                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>*\n\n点击目标的位置。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。也支持 `[Anchor]锚点名` 格式引用锚点对应的节点。若引用的前置节点或锚点识别结果为空，则视为动作失败。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。"
                 },
                 "target_offset": {
                     "title": "Target Offset Property",
@@ -1897,8 +2105,15 @@
                     "title": "Contact Property",
                     "description": "触点编号，用于区分不同的触控点。可选，默认 0 。",
                     "$ref": "#/$defs/jsonUInt32",
-                    "markdownDescription": "*uint*\n\n触点编号，用于区分不同的触控点。可选，默认 0 。\n\n- Adb 控制器：表示手指编号（0 为第一根手指，1 为第二根手指，以此类推）\n- Win32 控制器：表示鼠标按键编号（0 为左键，1 为右键，2 为中键，3 为 XBUTTON1，4 为 XBUTTON2）",
+                    "markdownDescription": "*uint*\n\n触点编号，用于区分不同的触控点。可选，默认 0 。\n\n- Adb 控制器：表示手指编号（0 为第一根手指，1 为第二根手指，以此类推）\n- Android Native 控制器：表示手指编号（0 为第一根手指，取值 0–15）\n- Win32 控制器：表示鼠标按键编号（0 为左键，1 为右键，2 为中键，3 为 XBUTTON1，4 为 XBUTTON2）",
                     "default": 0
+                },
+                "pressure": {
+                    "title": "Pressure Property",
+                    "description": "触点力度。可选，默认 1 。",
+                    "$ref": "#/$defs/jsonInt32",
+                    "markdownDescription": "*int*\n\n触点力度。可选，默认 1 。",
+                    "default": 1
                 }
             }
         },
@@ -1939,7 +2154,7 @@
                     "title": "Target Property",
                     "description": "长按目标的位置。可选，默认 true 。",
                     "$ref": "#/$defs/jsonTarget",
-                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>*\n\n长按目标的位置。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。"
+                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>*\n\n长按目标的位置。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。也支持 `[Anchor]锚点名` 格式引用锚点对应的节点。若引用的前置节点或锚点识别结果为空，则视为动作失败。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。"
                 },
                 "target_offset": {
                     "title": "Target Offset Property",
@@ -1958,8 +2173,15 @@
                     "title": "Contact Property",
                     "description": "触点编号，用于区分不同的触控点。可选，默认 0 。",
                     "$ref": "#/$defs/jsonUInt32",
-                    "markdownDescription": "*uint*\n\n触点编号，用于区分不同的触控点。可选，默认 0 。\n\n- Adb 控制器：表示手指编号（0 为第一根手指，1 为第二根手指，以此类推）\n- Win32 控制器：表示鼠标按键编号（0 为左键，1 为右键，2 为中键，3 为 XBUTTON1，4 为 XBUTTON2）",
+                    "markdownDescription": "*uint*\n\n触点编号，用于区分不同的触控点。可选，默认 0 。\n\n- Adb 控制器：表示手指编号（0 为第一根手指，1 为第二根手指，以此类推）\n- Android Native 控制器：表示手指编号（0 为第一根手指，取值 0–15）\n- Win32 控制器：表示鼠标按键编号（0 为左键，1 为右键，2 为中键，3 为 XBUTTON1，4 为 XBUTTON2）",
                     "default": 0
+                },
+                "pressure": {
+                    "title": "Pressure Property",
+                    "description": "触点力度。可选，默认 1 。",
+                    "$ref": "#/$defs/jsonInt32",
+                    "markdownDescription": "*int*\n\n触点力度。可选，默认 1 。",
+                    "default": 1
                 }
             }
         },
@@ -2000,7 +2222,7 @@
                     "title": "Begin Property",
                     "description": "滑动起点。可选，默认 true 。",
                     "$ref": "#/$defs/jsonTarget",
-                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>*\n\n滑动起点。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。"
+                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>*\n\n滑动起点。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。也支持 `[Anchor]锚点名` 格式引用锚点对应的节点。若引用的前置节点或锚点识别结果为空，则视为动作失败。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。"
                 },
                 "begin_offset": {
                     "title": "Begin Offset Property",
@@ -2012,27 +2234,47 @@
                     "title": "End Property",
                     "description": "滑动终点。可选，默认 true 。",
                     "$ref": "#/$defs/jsonTargetOrList",
-                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>* | *list<true | string | array<int, 2> | array<int, 4>>*\n\n滑动终点。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。\n\n- *list<...>*: v4.5.x 版本新增支持，可配置滑动途径点，列表内各项不抬手连续滑动。"
+                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>* | *list<true | string | array<int, 2> | array<int, 4>>*\n\n滑动终点。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。也支持 `[Anchor]锚点名` 格式引用锚点对应的节点。若引用的前置节点或锚点识别结果为空，则视为动作失败。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。\n\n- *list<...>*: v4.5.x 版本新增支持，可配置滑动途径点，列表内各项不抬手连续滑动。"
                 },
                 "end_offset": {
                     "title": "End Offset Property",
                     "description": "在 `end` 的基础上额外移动再作为终点，四个值分别相加。可选，默认 [0, 0, 0, 0] 。",
-                    "$ref": "#/$defs/jsonRect",
-                    "markdownDescription": "*array<int, 4>*\n\n在 `end` 的基础上额外移动再作为终点，四个值分别相加。可选，默认 [0, 0, 0, 0] 。"
+                    "$ref": "#/$defs/jsonRectOrList",
+                    "markdownDescription": "*array<int, 4>* | *list<array<int, 4>>*\n\n在 `end` 的基础上额外移动再作为终点，四个值分别相加。可选，默认 [0, 0, 0, 0] 。"
                 },
                 "duration": {
                     "title": "Duration Property",
                     "description": "滑动持续时间，单位毫秒。可选，默认 200 。",
-                    "$ref": "#/$defs/jsonUInt32",
-                    "markdownDescription": "*uint*\n\n滑动持续时间，单位毫秒。可选，默认 200 。",
+                    "$ref": "#/$defs/jsonUInt32OrList",
+                    "markdownDescription": "*uint* | *list<uint,>*\n\n滑动持续时间，单位毫秒。可选，默认 200 。",
                     "default": 200
+                },
+                "end_hold": {
+                    "title": "End Hold Property",
+                    "description": "滑动到终点后，额外等待一定时间再抬起，单位 ms。可选，默认 0。",
+                    "$ref": "#/$defs/jsonUInt32OrList",
+                    "markdownDescription": "*uint* | *list<uint,>*\n\n滑动到终点后，额外等待一定时间再抬起，单位 ms。可选，默认 0。",
+                    "default": 0
+                },
+                "only_hover": {
+                    "title": "Only Hover Property",
+                    "description": "仅鼠标悬停移动，无按下/抬起动作。可选，默认 false。",
+                    "$ref": "#/$defs/jsonBooleanFalse",
+                    "markdownDescription": "*bool*\n\n仅鼠标悬停移动，无按下/抬起动作。可选，默认 false。"
                 },
                 "contact": {
                     "title": "Contact Property",
                     "description": "触点编号，用于区分不同的触控点。可选，默认 0 。",
                     "$ref": "#/$defs/jsonUInt32",
-                    "markdownDescription": "*uint*\n\n触点编号，用于区分不同的触控点。可选，默认 0 。\n\n- Adb 控制器：表示手指编号（0 为第一根手指，1 为第二根手指，以此类推）\n- Win32 控制器：表示鼠标按键编号（0 为左键，1 为右键，2 为中键，3 为 XBUTTON1，4 为 XBUTTON2）",
+                    "markdownDescription": "*uint*\n\n触点编号，用于区分不同的触控点。可选，默认 0 。\n\n- Adb 控制器：表示手指编号（0 为第一根手指，1 为第二根手指，以此类推）\n- Android Native 控制器：表示手指编号（0 为第一根手指，取值 0–15）\n- Win32 控制器：表示鼠标按键编号（0 为左键，1 为右键，2 为中键，3 为 XBUTTON1，4 为 XBUTTON2）",
                     "default": 0
+                },
+                "pressure": {
+                    "title": "Pressure Property",
+                    "description": "触点力度。可选，默认 1 。",
+                    "$ref": "#/$defs/jsonInt32",
+                    "markdownDescription": "*int*\n\n触点力度。可选，默认 1 。",
+                    "default": 1
                 }
             }
         },
@@ -2158,14 +2400,14 @@
                     "title": "Contact Property",
                     "description": "触点编号，用于区分不同的触控点。可选，默认 0 。",
                     "$ref": "#/$defs/jsonUInt32",
-                    "markdownDescription": "*uint*\n\n触点编号，用于区分不同的触控点。可选，默认 0 。\n\n- Adb 控制器：表示手指编号（0 为第一根手指，1 为第二根手指，以此类推）\n- Win32 控制器：表示鼠标按键编号（0 为左键，1 为右键，2 为中键，3 为 XBUTTON1，4 为 XBUTTON2）",
+                    "markdownDescription": "*uint*\n\n触点编号，用于区分不同的触控点。可选，默认 0 。\n\n- Adb 控制器：表示手指编号（0 为第一根手指，1 为第二根手指，以此类推）\n- Android Native 控制器：表示手指编号（0 为第一根手指，取值 0–15）\n- Win32 控制器：表示鼠标按键编号（0 为左键，1 为右键，2 为中键，3 为 XBUTTON1，4 为 XBUTTON2）",
                     "default": 0
                 },
                 "target": {
                     "title": "Target Property",
                     "description": "触控目标的位置。可选，默认 true 。",
                     "$ref": "#/$defs/jsonTarget",
-                    "markdownDescription": "*true* | *string* | *array<int, 4>*\n\n触控目标的位置。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。\n\n- *array<int, 4>*: 目标为固定坐标区域内随机一点，[x, y, w, h]，若希望全屏可设为 [0, 0, 0, 0] 。"
+                    "markdownDescription": "*true* | *string* | *array<int, 4>*\n\n触控目标的位置。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。也支持 `[Anchor]锚点名` 格式引用锚点对应的节点。若引用的前置节点或锚点识别结果为空，则视为动作失败。\n\n- *array<int, 4>*: 目标为固定坐标区域内随机一点，[x, y, w, h]，若希望全屏可设为 [0, 0, 0, 0] 。"
                 },
                 "target_offset": {
                     "title": "Target Offset Property",
@@ -2249,7 +2491,7 @@
                     "title": "Contact Property",
                     "description": "触点编号，用于区分不同的触控点。可选，默认 0 。",
                     "$ref": "#/$defs/jsonUInt32",
-                    "markdownDescription": "*uint*\n\n触点编号，用于区分不同的触控点。可选，默认 0 。\n\n- Adb 控制器：表示手指编号（0 为第一根手指，1 为第二根手指，以此类推）\n- Win32 控制器：表示鼠标按键编号（0 为左键，1 为右键，2 为中键，3 为 XBUTTON1，4 为 XBUTTON2）",
+                    "markdownDescription": "*uint*\n\n触点编号，用于区分不同的触控点。可选，默认 0 。\n\n- Adb 控制器：表示手指编号（0 为第一根手指，1 为第二根手指，以此类推）\n- Android Native 控制器：表示手指编号（0 为第一根手指，取值 0–15）\n- Win32 控制器：表示鼠标按键编号（0 为左键，1 为右键，2 为中键，3 为 XBUTTON1，4 为 XBUTTON2）",
                     "default": 0
                 }
             }
@@ -2287,6 +2529,18 @@
         "Scroll": {
             "type": "object",
             "properties": {
+                "target": {
+                    "title": "Target Property",
+                    "description": "滚动目标的位置，鼠标会先移动到该位置再进行滚动。可选，默认 true 。",
+                    "$ref": "#/$defs/jsonTarget",
+                    "markdownDescription": "*true* | *string* | *array<int, 4>*\n\n滚动目标的位置，鼠标会先移动到该位置再进行滚动。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。也支持 `[Anchor]锚点名` 格式引用锚点对应的节点。若引用的前置节点或锚点识别结果为空，则视为动作失败。\n\n- *array<int, 4>*: 目标为固定坐标区域内随机一点，[x, y, w, h]，若希望全屏可设为 [0, 0, 0, 0] 。"
+                },
+                "target_offset": {
+                    "title": "Target Offset Property",
+                    "description": "在 `target` 的基础上额外移动再作为滚动目标，四个值分别相加。可选，默认 [0, 0, 0, 0] 。",
+                    "$ref": "#/$defs/jsonRect",
+                    "markdownDescription": "*array<int, 4>*\n\n在 `target` 的基础上额外移动再作为滚动目标，四个值分别相加。可选，默认 [0, 0, 0, 0] 。"
+                },
                 "dx": {
                     "title": "Scroll Dx Property",
                     "description": "水平滚动距离，正值向右滚动，负值向左滚动。可选，默认 0。建议使用 120 的整数倍（WHEEL_DELTA）。",
@@ -2296,10 +2550,10 @@
                 },
                 "dy": {
                     "title": "Scroll Dy Property",
-                    "description": "垂直滚动距离，正值向下滚动，负值向上滚动。可选，默认 0。建议使用 120 的整数倍（WHEEL_DELTA）。",
+                    "description": "垂直滚动距离，正值向上滚动，负值向下滚动。可选，默认 0。建议使用 120 的整数倍（WHEEL_DELTA）。",
                     "type": "integer",
                     "default": 0,
-                    "markdownDescription": "*int*\n\n垂直滚动距离，正值向下滚动，负值向上滚动。可选，默认 0。\n\n建议使用 120 的整数倍（WHEEL_DELTA）以获得最佳兼容性。"
+                    "markdownDescription": "*int*\n\n垂直滚动距离，正值向上滚动，负值向下滚动。可选，默认 0。\n\n建议使用 120 的整数倍（WHEEL_DELTA）以获得最佳兼容性。"
                 }
             }
         },
@@ -2871,12 +3125,12 @@
                     "type": "string",
                     "markdownDescription": "*string*\n\n要执行的 shell 命令。必选。\n\n例如 `getprop ro.build.version.sdk` 或 `settings put global animator_duration_scale 0`。\n\n> 注意：此动作仅对 ADB 控制器有效。"
                 },
-                "timeout": {
-                    "title": "Timeout Property",
-                    "description": "超时时间（毫秒）。可选，默认 20000 (20秒)。",
+                "shell_timeout": {
+                    "title": "Shell Timeout Property",
+                    "description": "超时时间（毫秒）。可选，默认 20000 (20秒)。设置为 -1 表示无限等待。",
                     "type": "integer",
                     "default": 20000,
-                    "markdownDescription": "*int*\n\n超时时间（毫秒）。可选，默认 20000 (20秒)。"
+                    "markdownDescription": "*int*\n\n超时时间（毫秒）。可选，默认 20000 (20秒)。\n\n设置为 -1 表示无限等待，永不超时。"
                 }
             },
             "required": [
@@ -2918,6 +3172,64 @@
                 }
             }
         },
+        "Screencap": {
+            "type": "object",
+            "properties": {
+                "filename": {
+                    "title": "Filename Property",
+                    "description": "保存截图的文件名（不含扩展名）。可选，默认使用 \"时间戳_节点名\" 格式。",
+                    "type": "string",
+                    "markdownDescription": "*string*\n\n保存截图的文件名（不含扩展名）。可选，默认使用 `时间戳_节点名` 格式。\n\n截图保存在 `log_dir/screencap/` 目录下。"
+                },
+                "format": {
+                    "title": "Format Property",
+                    "description": "图片格式。可选，默认 \"png\"。",
+                    "type": "string",
+                    "enum": ["png", "jpg", "jpeg"],
+                    "default": "png",
+                    "markdownDescription": "*string*\n\n图片格式。可选，默认 `\"png\"`（无损）。\n\n可选值：`\"png\"` | `\"jpg\"` | `\"jpeg\"`"
+                },
+                "quality": {
+                    "title": "Quality Property",
+                    "description": "图片质量，仅对 jpg/jpeg 有效。可选，默认 100。",
+                    "type": "integer",
+                    "default": 100,
+                    "minimum": 0,
+                    "maximum": 100,
+                    "markdownDescription": "*int*\n\n图片质量（0-100），仅对 `jpg` / `jpeg` 格式有效。可选，默认 100。\n\n`png` 格式始终为无损压缩，此字段无效。"
+                }
+            }
+        },
+        "ScreencapV1": {
+            "properties": {
+                "action": {
+                    "const": "Screencap"
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "#/$defs/Screencap"
+                }
+            ]
+        },
+        "ScreencapV2": {
+            "properties": {
+                "type": {
+                    "const": "Screencap"
+                },
+                "param": {
+                    "unevaluatedProperties": false,
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/Screencap"
+                        },
+                        {
+                            "$ref": "#/$defs/jsonComments"
+                        }
+                    ]
+                }
+            }
+        },
         "CustomAction": {
             "type": "object",
             "properties": {
@@ -2925,7 +3237,7 @@
                     "title": "Target Property",
                     "description": "目标的位置，会通过 `MaaCustomActionCallback`.`box` 传出。可选，默认 true 。",
                     "$ref": "#/$defs/jsonTarget",
-                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>*\n\n目标的位置，会通过 `MaaCustomActionCallback`.`box` 传出。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。"
+                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>*\n\n目标的位置，会通过 `MaaCustomActionCallback`.`box` 传出。可选，默认 true 。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。也支持 `[Anchor]锚点名` 格式引用锚点对应的节点。若引用的前置节点或锚点识别结果为空，则视为动作失败。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。"
                 },
                 "target_offset": {
                     "title": "Target Offset Property",
@@ -3052,6 +3364,8 @@
                 "StopApp",
                 "StopTask",
                 "Command",
+                "Shell",
+                "Screencap",
                 "Custom"
             ]
         },
@@ -3228,6 +3542,27 @@
                     "anyOf": [
                         {
                             "$ref": "#/$defs/CustomAction/properties/custom_action_param"
+                        }
+                    ]
+                },
+                "cmd": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Shell/properties/cmd"
+                        }
+                    ]
+                },
+                "end_hold": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Swipe/properties/end_hold"
+                        }
+                    ]
+                },
+                "only_hover": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/Swipe/properties/only_hover"
                         }
                     ]
                 }
@@ -3472,6 +3807,17 @@
                     }
                 },
                 {
+                    "label": "ScreencapV1",
+                    "body": "^ \"Screencap\""
+                },
+                {
+                    "label": "ScreencapV2",
+                    "body": {
+                        "type": "Screencap",
+                        "param": {}
+                    }
+                },
+                {
                     "label": "CustomActionV1",
                     "body": "^ \"Custom\",\n\"custom_action\": \"\""
                 },
@@ -3552,6 +3898,9 @@
                 },
                 {
                     "$ref": "#/$defs/ShellV1"
+                },
+                {
+                    "$ref": "#/$defs/ScreencapV1"
                 },
                 {
                     "$ref": "#/$defs/CustomActionV1"
@@ -3638,6 +3987,9 @@
                             "$ref": "#/$defs/ShellV2"
                         },
                         {
+                            "$ref": "#/$defs/ScreencapV2"
+                        },
+                        {
                             "$ref": "#/$defs/CustomActionV2"
                         }
                     ]
@@ -3696,7 +4048,7 @@
                     "title": "Target Property",
                     "description": "等待目标的位置。可选，默认 true。",
                     "$ref": "#/$defs/jsonTarget",
-                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>*\n\n等待目标的位置。可选，默认 true。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。"
+                    "markdownDescription": "*true* | *string* | *array<int, 2>* | *array<int, 4>*\n\n等待目标的位置。可选，默认 true。\n\n- *true*: 目标为本节点中刚刚识别到的位置（即自身）。\n\n- *string*: 填写节点名，目标为之前执行过的某节点识别到的位置。也支持 `[Anchor]锚点名` 格式引用锚点对应的节点。若引用的前置节点或锚点识别结果为空，则视为动作失败。\n\n- *array<int, 2>*: 固定坐标点 [x, y]。\n\n- *array<int, 4>*: 固定坐标区域 [x, y, w, h]，会在矩形内随机选取一点（越靠近中心概率越高，边缘概率相对较低），若希望全屏可设为 [0, 0, 0, 0] 。"
                 },
                 "target_offset": {
                     "title": "Target Offset Property",
@@ -3745,9 +4097,9 @@
                 },
                 "timeout": {
                     "title": "Timeout Property",
-                    "description": "识别超时时间，毫秒。可选，默认 20 * 1000 。",
-                    "$ref": "#/$defs/jsonNInt64",
-                    "markdownDescription": "*uint*\n\n识别超时时间，毫秒。可选，默认 20 * 1000 。",
+                    "description": "识别超时时间，毫秒。可选，默认 20 * 1000 。设置为 -1 表示无限等待。",
+                    "$ref": "#/$defs/jsonInt64",
+                    "markdownDescription": "*int*\n\n识别超时时间，毫秒。可选，默认 20 * 1000 。\n\n设置为 -1 表示无限等待，永不超时。",
                     "default": 20000
                 }
             }
@@ -3828,10 +4180,10 @@
                 },
                 "timeout": {
                     "title": "Timeout Property",
-                    "description": "识别超时时间，毫秒。可选，默认 20 * 1000 。",
-                    "$ref": "#/$defs/jsonNInt64",
+                    "description": "识别超时时间，毫秒。可选，默认 20 * 1000 。设置为 -1 表示无限等待。",
+                    "$ref": "#/$defs/jsonInt64",
                     "default": 20000,
-                    "markdownDescription": "*uint*\n\n识别超时时间，毫秒。可选，默认 20 * 1000 。\n\n具体逻辑为 `while(!timeout) { foreach(next); sleep_until(rate_limit); }` 。"
+                    "markdownDescription": "*int*\n\n识别超时时间，毫秒。可选，默认 20 * 1000 。\n\n设置为 -1 表示无限等待，永不超时。\n\n具体逻辑为 `while(!timeout) { foreach(next); sleep_until(rate_limit); }` 。"
                 },
                 "on_error": {
                     "title": "On Error Property",
@@ -3842,8 +4194,8 @@
                 "anchor": {
                     "title": "Anchor Property",
                     "description": "锚点名称。可选，默认空。",
-                    "$ref": "#/$defs/jsonStringOrList",
-                    "markdownDescription": "*string* | *list<string, >*\n\n锚点名称。可选，默认空。\n\n当节点执行成功后，会将该锚点名设置为当前节点。多个节点可设置同一个锚点名，后执行的会覆盖先执行的。\n\n在 `next` 或 `on_error` 中可通过 `[Anchor]` 属性引用该锚点，运行时会解析为最后设置该锚点的节点。\n\n详见文档中的「节点属性」章节。"
+                    "$ref": "#/$defs/jsonStringOrListOrMap",
+                    "markdownDescription": "*string* | *list<string, >* | *object*\n\n锚点名称。可选，默认空。\n\n当节点执行成功后，会将该锚点名设置为对应的节点。多个节点可设置同一个锚点名，后执行的会覆盖先执行的。\n\n支持三种格式：\n- 字符串：`\"anchor\": \"MyAnchor\"` - 将锚点设置为当前节点\n- 字符串数组：`\"anchor\": [\"A\", \"B\"]` - 将多个锚点都设置为当前节点\n- 对象：`\"anchor\": {\"A\": \"TargetNode\", \"B\": \"\"}` - 将锚点 A 设置为 TargetNode，清除锚点 B（空字符串表示清除该锚点）\n\n在 `next` 或 `on_error` 中可通过 `[Anchor]` 属性引用该锚点，运行时会解析为最后设置该锚点的节点。\n\n详见文档中的「节点属性」章节。"
                 },
                 "inverse": {
                     "title": "Inverse Property",
@@ -3888,6 +4240,26 @@
                     "description": "行动动作后 到 识别 next，等待画面不动了的时间，毫秒。可选，默认 0 ，即不等待。",
                     "$ref": "#/$defs/WaitFreezesOrNInt64",
                     "markdownDescription": "*uint* | *object*\n\n行动动作后 到 识别 next，等待画面不动了的时间，毫秒。可选，默认 0 ，即不等待。\n\n连续 `pre_wait_freezes` 毫秒 画面 **没有较大变化** 才会退出动作。\n\n若为 object，可设置更多参数，详见 [等待画面静止](#等待画面静止)。\n\n具体的顺序为 `pre_wait_freezes` - `pre_delay` - `action` - `post_wait_freezes` - `post_delay` 。"
+                },
+                "repeat": {
+                    "title": "Repeat Property",
+                    "description": "动作重复执行次数。可选，默认 1 ，即不重复。",
+                    "$ref": "#/$defs/jsonUInt32",
+                    "default": 1,
+                    "markdownDescription": "*uint*\n\n动作重复执行次数。可选，默认 1 ，即不重复。\n\n执行流程为 `pre_wait_freezes` - `pre_delay` - `action` - [`repeat_wait_freezes` - `repeat_delay` - `action`] × (repeat-1) - `post_wait_freezes` - `post_delay` 。"
+                },
+                "repeat_delay": {
+                    "title": "Repeat Delay Property",
+                    "description": "每次重复动作之间的延迟，毫秒。可选，默认 0 。",
+                    "$ref": "#/$defs/jsonNInt64",
+                    "default": 0,
+                    "markdownDescription": "*uint*\n\n每次重复动作之间的延迟，毫秒。可选，默认 0 。\n\n仅当 `repeat` > 1 时生效，在第二次及之后的每次动作执行前等待。"
+                },
+                "repeat_wait_freezes": {
+                    "title": "Repeat Wait Freezes Property",
+                    "description": "每次重复动作之间等待画面不动了的时间，毫秒。可选，默认 0 ，即不等待。",
+                    "$ref": "#/$defs/WaitFreezesOrNInt64",
+                    "markdownDescription": "*uint* | *object*\n\n每次重复动作之间等待画面不动了的时间，毫秒。可选，默认 0 ，即不等待。\n\n仅当 `repeat` > 1 时生效，在第二次及之后的每次动作执行前等待画面静止。\n\n若为 object，可设置更多参数，详见 [等待画面静止](#等待画面静止)。"
                 },
                 "focus": {
                     "title": "Focus Property",


### PR DESCRIPTION
## 变更

- 修复追踪资源 OCR 失败时对 `None` 做减法导致的异常
- 修复潜能卡片位置识别失败时 `next(...)` 抛出 `StopIteration`、无法执行兜底的问题
- 恢复 MaaFramework schema 的每日自动同步，修正遗留的模板仓库判断
- 同步 MaaFramework `main` 的全部 6 个 schema，并对下载结果执行失败重试和 JSON 校验
- 保持 MaaFw 依赖不锁版本，发布构建继续使用最新版本

## 验证

- Ruff 0.16.4 静态检查通过
- Ruff BugBear 运行时陷阱检查通过
- actionlint 1.7.12 工作流检查通过
- 两条异常路径回归验证通过
- 使用未锁定安装的 MaaFw 5.13.0b5 完成 8 组资源覆盖检查
- 6 个 schema 的 Git blob 哈希与 MaaFramework 上游完全一致
- `git diff --check` 通过